### PR TITLE
Add label - 75% to max borrow button

### DIFF
--- a/packages/ui/components/pages/Fuse/Modals/PoolModal/AmountSelect.tsx
+++ b/packages/ui/components/pages/Fuse/Modals/PoolModal/AmountSelect.tsx
@@ -699,6 +699,7 @@ const TokenNameAndMaxButton = ({
 
       <Button height={8} onClick={setToMax} isLoading={isMaxLoading}>
         MAX
+        {mode === FundOperationMode.BORROW && ' (75%)'}
       </Button>
     </Row>
   );


### PR DESCRIPTION
## Description

Add label - 75%  to the max button in case of borrow

## Type of change

- [ ] Docs change / dependency upgrade
- [ ] Configuration / tooling changes
- [x] Refactoring
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Requires changes in customer code

## Related Issue(s)

Fixes [issue74](https://github.com/Midas-Protocol/monorepo/issues/74)


![Screen Shot 2022-05-30 at 6 14 15 PM](https://user-images.githubusercontent.com/37353416/171063941-ccbe931f-25b8-44ec-a117-b134e95fa105.png)

