### PR TITLE
Refactor `useFusePoolData` Fiat instead of Native

### DIFF
--- a/packages/ui/components/pages/Fuse/FusePoolEditPage/FlywheelEdit/EditFlywheelModal.tsx
+++ b/packages/ui/components/pages/Fuse/FusePoolEditPage/FlywheelEdit/EditFlywheelModal.tsx
@@ -21,7 +21,6 @@ import {
   useToast,
   VStack,
 } from '@chakra-ui/react';
-import { FusePoolData, NativePricedFuseAsset } from '@midas-capital/sdk';
 import { Contract, utils } from 'ethers';
 import { useCallback, useEffect, useState } from 'react';
 import DatePicker from 'react-datepicker';
@@ -32,6 +31,7 @@ import ClipboardValue from '@ui/components/shared/ClipboardValue';
 import { ModalDivider } from '@ui/components/shared/Modal';
 import { useRari } from '@ui/context/RariContext';
 import { useColors } from '@ui/hooks/useColors';
+import { MarketData, PoolData } from '@ui/hooks/useFusePoolData';
 import { useTokenBalance } from '@ui/hooks/useTokenBalance';
 import { useTokenData } from '@ui/hooks/useTokenData';
 import SmallWhiteCircle from '@ui/images/small-white-circle.png';
@@ -67,7 +67,7 @@ const EditFlywheelModal = ({
   onClose,
 }: {
   flywheel: Flywheel;
-  pool: FusePoolData;
+  pool: PoolData;
   isOpen: boolean;
   onClose: () => void;
 }) => {
@@ -88,9 +88,7 @@ const EditFlywheelModal = ({
   const [fundingAmount, setTransactionPendingAmount] = useState<number>(0);
   const [supplySpeed, setSupplySpeed] = useState<string>('0.0');
   const [isTransactionPending, setTransactionPending] = useState(false);
-  const [selectedMarket, selectMarket] = useState<NativePricedFuseAsset | undefined>(
-    pool?.assets[0]
-  );
+  const [selectedMarket, selectMarket] = useState<MarketData | undefined>(pool?.assets[0]);
   const [endDate, setEndDate] = useState<Date | null>(null);
   const [isDateEditable, setDateEditable] = useState<boolean>(false);
   const [isSpeedEditable, setSpeedEditable] = useState<boolean>(false);
@@ -283,7 +281,7 @@ const EditFlywheelModal = ({
               </Heading>
 
               <HStack alignItems={'center'} justifyContent="center" width={'100%'}>
-                {pool.assets.map((asset: NativePricedFuseAsset, index: number) => (
+                {pool.assets.map((asset, index) => (
                   <FilterButton
                     key={index}
                     isSelected={asset.cToken === selectedMarket?.cToken}

--- a/packages/ui/components/pages/Fuse/FusePoolEditPage/FlywheelEdit/index.tsx
+++ b/packages/ui/components/pages/Fuse/FusePoolEditPage/FlywheelEdit/index.tsx
@@ -15,7 +15,6 @@ import {
   Tr,
   useDisclosure,
 } from '@chakra-ui/react';
-import { FusePoolData } from '@midas-capital/sdk';
 import React, { useCallback, useMemo, useState } from 'react';
 import { useAccount } from 'wagmi';
 
@@ -29,13 +28,14 @@ import { useIsUpgradeable } from '@ui/hooks/fuse/useIsUpgradable';
 import { useFlywheelsForPool } from '@ui/hooks/rewards/useFlywheelsForPool';
 import { useCTokensUnderlying } from '@ui/hooks/rewards/usePoolIncentives';
 import { useColors } from '@ui/hooks/useColors';
+import { PoolData } from '@ui/hooks/useFusePoolData';
 import { useTokenBalance } from '@ui/hooks/useTokenBalance';
 import { useTokenData } from '@ui/hooks/useTokenData';
 import { Flywheel } from '@ui/types/ComponentPropsType';
 import { Center, Column } from '@ui/utils/chakraUtils';
 import { shortAddress } from '@ui/utils/shortAddress';
 
-const FlywheelEdit = ({ pool }: { pool: FusePoolData }) => {
+const FlywheelEdit = ({ pool }: { pool: PoolData }) => {
   const { isOpen: isAddOpen, onOpen: openAdd, onClose: closeAdd } = useDisclosure();
   const { isOpen: isEditOpen, onOpen: openEdit, onClose: closeEdit } = useDisclosure();
   const { isOpen: isCreateOpen, onOpen: openCreate, onClose: closeCreate } = useDisclosure();
@@ -147,7 +147,7 @@ const FlywheelRow = ({
   onClick,
 }: {
   flywheel: Flywheel;
-  pool: FusePoolData;
+  pool: PoolData;
   onClick: (fw: Flywheel) => void;
 }) => {
   const { data: accountData } = useAccount();

--- a/packages/ui/components/pages/Fuse/FusePoolPage/CollateralRatioBar.tsx
+++ b/packages/ui/components/pages/Fuse/FusePoolPage/CollateralRatioBar.tsx
@@ -8,16 +8,15 @@ import { useBorrowLimit } from '@ui/hooks/useBorrowLimit';
 import { smallUsdFormatter } from '@ui/utils/bigUtils';
 import { Row } from '@ui/utils/chakraUtils';
 
-export const CollateralRatioBar = ({
-  assets,
-  borrowUSD,
-}: {
+interface CollateralRatioBarProps {
   assets: NativePricedFuseAsset[];
-  borrowUSD: number;
-}) => {
+  borrowFiat: number;
+}
+
+export const CollateralRatioBar = ({ assets, borrowFiat }: CollateralRatioBarProps) => {
   const maxBorrow = useBorrowLimit(assets);
 
-  const ratio = (borrowUSD / maxBorrow) * 100;
+  const ratio = (borrowFiat / maxBorrow) * 100;
 
   useEffect(() => {
     if (ratio > 95) {
@@ -36,7 +35,7 @@ export const CollateralRatioBar = ({
 
         <Tooltip label={'This is how much you have borrowed.'}>
           <Text flexShrink={0} mt="2px" mr={3} fontSize="10px">
-            {smallUsdFormatter(borrowUSD)}
+            {smallUsdFormatter(borrowFiat)}
           </Text>
         </Tooltip>
 

--- a/packages/ui/components/pages/Fuse/FusePoolPage/SupplyList.tsx
+++ b/packages/ui/components/pages/Fuse/FusePoolPage/SupplyList.tsx
@@ -40,17 +40,19 @@ import { aprFormatter, smallUsdFormatter, tokenFormatter } from '@ui/utils/bigUt
 import { Row, useIsMobile } from '@ui/utils/chakraUtils';
 import { URL_MIDAS_DOCS } from '@ui/utils/constants';
 
-export const SupplyList = ({
-  assets,
-  supplyBalanceNative,
-  comptrollerAddress,
-  rewards = [],
-}: {
+interface SupplyListProps {
   assets: NativePricedFuseAsset[];
-  supplyBalanceNative: number;
+  supplyBalanceFiat: number;
   comptrollerAddress: string;
   rewards?: FlywheelMarketRewardsInfo[];
-}) => {
+}
+
+export const SupplyList = ({
+  assets,
+  supplyBalanceFiat,
+  comptrollerAddress,
+  rewards = [],
+}: SupplyListProps) => {
   const suppliedAssets = assets.filter((asset) => asset.supplyBalanceNative > 1);
   const nonSuppliedAssets = assets.filter(
     (asset) => asset.supplyBalanceNative < 1 && !asset.isSupplyPaused
@@ -68,7 +70,7 @@ export const SupplyList = ({
           textAlign={'left'}
           fontSize={{ base: '3.8vw', sm: 'lg' }}
         >
-          Your Supply Balance: {smallUsdFormatter(supplyBalanceNative)}
+          Your Supply Balance: {smallUsdFormatter(supplyBalanceFiat)}
         </TableCaption>
         <Thead>
           {assets.length > 0 ? (

--- a/packages/ui/components/pages/Fuse/FusePoolPage/index.tsx
+++ b/packages/ui/components/pages/Fuse/FusePoolPage/index.tsx
@@ -41,8 +41,6 @@ const FusePoolPage = memo(() => {
   const { data: marketRewards } = useFlywheelRewardsForPool(data?.comptroller);
   const rewardTokens = useRewardTokensOfPool(data?.comptroller);
 
-  console.log({ data });
-
   const { cPage } = useColors();
 
   return (

--- a/packages/ui/components/pages/Fuse/FusePoolPage/index.tsx
+++ b/packages/ui/components/pages/Fuse/FusePoolPage/index.tsx
@@ -147,7 +147,7 @@ const FusePoolPage = memo(() => {
                 <SupplyList
                   assets={data.assets}
                   comptrollerAddress={data.comptroller}
-                  supplyBalanceNative={data.totalSupplyBalanceNative}
+                  supplyBalanceFiat={data.totalSupplyBalanceFiat}
                   rewards={marketRewards}
                 />
               ) : (

--- a/packages/ui/components/pages/Fuse/FusePoolPage/index.tsx
+++ b/packages/ui/components/pages/Fuse/FusePoolPage/index.tsx
@@ -41,6 +41,8 @@ const FusePoolPage = memo(() => {
   const { data: marketRewards } = useFlywheelRewardsForPool(data?.comptroller);
   const rewardTokens = useRewardTokensOfPool(data?.comptroller);
 
+  console.log({ data });
+
   const { cPage } = useColors();
 
   return (
@@ -100,25 +102,24 @@ const FusePoolPage = memo(() => {
               <SimpleGrid columns={{ base: 2, md: 4 }} spacing="4">
                 <PoolStat
                   label="Total Supply"
-                  value={data ? midUsdFormatter(data.totalSuppliedNative) : undefined}
+                  value={data ? midUsdFormatter(data.totalSuppliedFiat) : undefined}
                 />
                 <PoolStat
                   label="Total Borrow"
-                  value={data ? midUsdFormatter(data?.totalBorrowedNative) : undefined}
+                  value={data ? midUsdFormatter(data?.totalBorrowedFiat) : undefined}
                 />
                 <PoolStat
                   label="Liquidity"
-                  value={data ? midUsdFormatter(data?.totalLiquidityNative) : undefined}
+                  value={data ? midUsdFormatter(data?.totalLiquidityFiat) : undefined}
                 />
                 <PoolStat
                   label="Utilization"
                   value={
                     data
-                      ? data.totalSuppliedNative.toString() === '0'
+                      ? data.totalSuppliedFiat.toString() === '0'
                         ? '0%'
-                        : ((data?.totalBorrowedNative / data?.totalSuppliedNative) * 100).toFixed(
-                            2
-                          ) + '%'
+                        : ((data?.totalBorrowedFiat / data?.totalSuppliedFiat) * 100).toFixed(2) +
+                          '%'
                       : undefined
                   }
                 />
@@ -128,7 +129,7 @@ const FusePoolPage = memo(() => {
           {
             /* If they have some asset enabled as collateral, show the collateral ratio bar */
             data && data.assets.some((asset) => asset.membership) ? (
-              <CollateralRatioBar assets={data.assets} borrowUSD={data.totalBorrowBalanceNative} />
+              <CollateralRatioBar assets={data.assets} borrowFiat={data.totalBorrowBalanceFiat} />
             ) : null
           }
           <RowOrColumn

--- a/packages/ui/components/pages/Fuse/FusePoolsPage/FusePoolCard.tsx
+++ b/packages/ui/components/pages/Fuse/FusePoolsPage/FusePoolCard.tsx
@@ -105,7 +105,7 @@ const PoolCard = ({ data: pool }: { data: FusePoolData }) => {
               Your Supply <br></br> Balance
             </Text>
             <Text mt="1.5" fontWeight="bold">
-              {fusePoolData && smallUsdFormatter(fusePoolData.totalSupplyBalanceNative)}
+              {fusePoolData && smallUsdFormatter(fusePoolData.totalSupplyBalanceFiat)}
             </Text>
           </Column>
           <chakra.div h="16" w="1px" bgColor={cCard.dividerColor} />

--- a/packages/ui/components/pages/Fuse/FusePoolsPage/FusePoolCard.tsx
+++ b/packages/ui/components/pages/Fuse/FusePoolsPage/FusePoolCard.tsx
@@ -8,35 +8,37 @@ import { CTokenIcon } from '@ui/components/shared/CTokenIcon';
 import { useRari } from '@ui/context/RariContext';
 import { usePoolRiskScoreGradient } from '@ui/hooks/fuse/usePoolRiskScoreGradient';
 import { useColors } from '@ui/hooks/useColors';
-import { useFusePoolData } from '@ui/hooks/useFusePoolData';
 import { letterScore, usePoolRSS } from '@ui/hooks/useRSS';
 import { useUSDPrice } from '@ui/hooks/useUSDPrice';
 import { smallUsdFormatter } from '@ui/utils/bigUtils';
 import { Column, Row } from '@ui/utils/chakraUtils';
 
-const PoolCard = ({ data: pool }: { data: FusePoolData }) => {
-  const { data: fusePoolData } = useFusePoolData(pool.id.toString());
-  const { data: rss, error: rssError } = usePoolRSS(pool.id);
+interface PoolCardProps {
+  data: FusePoolData;
+  isMostSupplied?: boolean;
+}
+const PoolCard = ({ data }: PoolCardProps) => {
+  const { data: rss, error: rssError } = usePoolRSS(data.id);
   const rssScore = !rssError && rss ? letterScore(rss.totalScore) : '?';
   const tokens = useMemo(() => {
-    return pool.underlyingTokens.map((address, index) => ({
+    return data.underlyingTokens.map((address, index) => ({
       address,
-      symbol: pool.underlyingSymbols[index],
+      symbol: data.underlyingSymbols[index],
     }));
-  }, [pool.underlyingSymbols, pool.underlyingTokens]);
+  }, [data.underlyingSymbols, data.underlyingTokens]);
   const scoreGradient = usePoolRiskScoreGradient(rssScore);
 
   const { cCard } = useColors();
 
   const router = useRouter();
   const { setLoading, currentChain, coingeckoId } = useRari();
-  const { data: usdPrice } = useUSDPrice(coingeckoId);
 
+  const { data: usdPrice } = useUSDPrice(coingeckoId);
   return (
     <motion.div whileHover={{ scale: 1.05 }}>
       <Flex
         w="100%"
-        key={pool.id}
+        key={data.id}
         pt={6}
         bgColor={cCard.bgColor}
         borderColor={cCard.borderColor}
@@ -53,11 +55,11 @@ const PoolCard = ({ data: pool }: { data: FusePoolData }) => {
           justifyContent="center"
         >
           <Heading fontWeight="bold" fontSize={'xl'} ml="2" color={cCard.txtColor}>
-            {pool.name}
+            {data.name}
           </Heading>
         </Row>
         <Row crossAxisAlignment="center" mainAxisAlignment="space-between" mx="6">
-          {pool.underlyingTokens.length === 0 ? null : (
+          {data.underlyingTokens.length === 0 ? null : (
             <AvatarGroup size="sm" max={30}>
               {tokens.slice(0, 10).map(({ address }) => {
                 return <CTokenIcon key={address} address={address} />;
@@ -85,7 +87,7 @@ const PoolCard = ({ data: pool }: { data: FusePoolData }) => {
               Total Supply
             </Text>
             <Text mt="1.5" fontWeight="bold">
-              {usdPrice && smallUsdFormatter(pool.totalSuppliedNative * usdPrice)}
+              {usdPrice && smallUsdFormatter(data.totalSuppliedNative * usdPrice)}
             </Text>
           </Column>
           <chakra.div h="16" w="1px" bgColor={cCard.dividerColor} />
@@ -94,7 +96,7 @@ const PoolCard = ({ data: pool }: { data: FusePoolData }) => {
               Total borrowed
             </Text>
             <Text mt="1.5" fontWeight="bold">
-              {usdPrice && smallUsdFormatter(pool.totalBorrowedNative * usdPrice)}
+              {usdPrice && smallUsdFormatter(data.totalBorrowedNative * usdPrice)}
             </Text>
           </Column>
         </Row>
@@ -105,7 +107,7 @@ const PoolCard = ({ data: pool }: { data: FusePoolData }) => {
               Your Supply <br></br> Balance
             </Text>
             <Text mt="1.5" fontWeight="bold">
-              {fusePoolData && smallUsdFormatter(fusePoolData.totalSupplyBalanceFiat)}
+              {usdPrice && smallUsdFormatter(data.totalSupplyBalanceNative * usdPrice)}
             </Text>
           </Column>
           <chakra.div h="16" w="1px" bgColor={cCard.dividerColor} />
@@ -114,7 +116,7 @@ const PoolCard = ({ data: pool }: { data: FusePoolData }) => {
               Your borrowed <br></br> Balance
             </Text>
             <Text mt="1.5" fontWeight="bold">
-              {fusePoolData && smallUsdFormatter(fusePoolData.totalBorrowBalanceNative)}
+              {usdPrice && smallUsdFormatter(data.totalBorrowBalanceNative * usdPrice)}
             </Text>
           </Column>
         </Row>
@@ -122,7 +124,7 @@ const PoolCard = ({ data: pool }: { data: FusePoolData }) => {
           <Button
             onClick={() => {
               setLoading(true);
-              router.push(`/${currentChain.id}/pool/` + pool.id);
+              router.push(`/${currentChain.id}/pool/` + data.id);
             }}
           >
             View Details

--- a/packages/ui/components/pages/Fuse/FusePoolsPage/FusePoolList.tsx
+++ b/packages/ui/components/pages/Fuse/FusePoolsPage/FusePoolList.tsx
@@ -94,7 +94,7 @@ const FusePoolList = () => {
               gridGap="8"
               gridRowGap="8"
             >
-              {currentPools.map((pool: FusePoolData, index: number) => {
+              {currentPools.map((pool, index: number) => {
                 return <PoolCard data={pool} key={index} />;
               })}
             </Grid>

--- a/packages/ui/components/pages/Fuse/FusePoolsPage/FusePoolRow.tsx
+++ b/packages/ui/components/pages/Fuse/FusePoolsPage/FusePoolRow.tsx
@@ -205,7 +205,7 @@ const PoolRow = ({
                 <Row crossAxisAlignment="center" mainAxisAlignment="center" width="100%">
                   <Text fontWeight="bold" textAlign="center">
                     {isMostSupplied
-                      ? fusePoolData && smallUsdFormatter(fusePoolData.totalSupplyBalanceNative)
+                      ? fusePoolData && smallUsdFormatter(fusePoolData.totalSupplyBalanceFiat)
                       : '$0.00'}
                   </Text>
                 </Row>

--- a/packages/ui/components/pages/Fuse/FusePoolsPage/FusePoolRow.tsx
+++ b/packages/ui/components/pages/Fuse/FusePoolsPage/FusePoolRow.tsx
@@ -23,7 +23,6 @@ import { usePoolDetails } from '@ui/hooks/fuse/usePoolDetails';
 import { usePoolRiskScoreGradient } from '@ui/hooks/fuse/usePoolRiskScoreGradient';
 import { useRewardTokensOfPool } from '@ui/hooks/rewards/useRewardTokensOfPool';
 import { useColors } from '@ui/hooks/useColors';
-import { useFusePoolData } from '@ui/hooks/useFusePoolData';
 import { letterScore, usePoolRSS } from '@ui/hooks/useRSS';
 import { useUSDPrice } from '@ui/hooks/useUSDPrice';
 import { convertMantissaToAPR, convertMantissaToAPY } from '@ui/utils/apyUtils';
@@ -31,33 +30,30 @@ import { smallUsdFormatter } from '@ui/utils/bigUtils';
 import { Column, Row } from '@ui/utils/chakraUtils';
 import { shortAddress } from '@ui/utils/shortAddress';
 
-const PoolRow = ({
-  data: pool,
-  isMostSupplied,
-}: {
+interface PoolRowProps {
   data: FusePoolData;
   isMostSupplied?: boolean;
-}) => {
-  const { data: fusePoolData } = useFusePoolData(pool.id.toString());
-  const { data: rss, error: rssError } = usePoolRSS(pool.id);
+}
+
+const PoolRow = ({ data, isMostSupplied }: PoolRowProps) => {
+  const router = useRouter();
+  const { data: rss, error: rssError } = usePoolRSS(data.id);
   const rssScore = !rssError && rss ? letterScore(rss.totalScore) : '?';
-  const tokens = useMemo(
-    () =>
-      pool.underlyingTokens.map((address, index) => ({
-        address,
-        symbol: pool.underlyingSymbols[index],
-      })),
-    [pool.underlyingSymbols, pool.underlyingTokens]
-  );
+  const tokens = useMemo(() => {
+    return data.underlyingTokens.map((address, index) => ({
+      address,
+      symbol: data.underlyingSymbols[index],
+    }));
+  }, [data.underlyingSymbols, data.underlyingTokens]);
+
   const scoreGradient = usePoolRiskScoreGradient(rssScore);
-  const poolDetails = usePoolDetails(fusePoolData?.assets);
-  const rewardTokens = useRewardTokensOfPool(fusePoolData?.comptroller);
+  const poolDetails = usePoolDetails(data.assets);
+  const rewardTokens = useRewardTokensOfPool(data.comptroller);
   const { cCard, cOutlineBtn } = useColors();
   const [showDetails, setShowDetails] = useState<boolean>(false);
   const toggleDetails = useCallback(() => {
     setShowDetails((previous) => !previous);
   }, [setShowDetails]);
-  const router = useRouter();
 
   const { scanUrl, setLoading, currentChain, coingeckoId } = useRari();
   const { data: usdPrice } = useUSDPrice(coingeckoId);
@@ -92,7 +88,7 @@ const PoolRow = ({
         cursor="pointer"
         onClick={() => {
           setLoading(true);
-          router.push(`/${currentChain.id}/pool/` + pool.id);
+          router.push(`/${currentChain.id}/pool/` + data.id);
         }}
         py={4}
         px={6}
@@ -100,7 +96,7 @@ const PoolRow = ({
       >
         <VStack flex={6} alignItems={'flex-start'} spacing={1}>
           <Heading mt={rewardTokens.length ? 2 : 0} fontWeight="bold" fontSize={'xl'}>
-            {pool.name}
+            {data.name}
           </Heading>
           {rewardTokens.length && (
             <HStack m={0}>
@@ -125,7 +121,7 @@ const PoolRow = ({
         </VStack>
 
         <VStack flex={4} alignItems="flex-start">
-          {pool.underlyingTokens.length === 0 ? null : (
+          {data.underlyingTokens.length === 0 ? null : (
             <AvatarGroup size="sm" max={30}>
               {tokens.slice(0, 10).map((token, i) => (
                 <CTokenIcon key={i} address={token.address} />
@@ -136,13 +132,13 @@ const PoolRow = ({
 
         <VStack flex={2}>
           <Text fontWeight="bold" textAlign="center">
-            {usdPrice && smallUsdFormatter(pool.totalSuppliedNative * usdPrice)}
+            {usdPrice && smallUsdFormatter(data.totalSuppliedNative * usdPrice)}
           </Text>
         </VStack>
 
         <VStack flex={2}>
           <Text fontWeight="bold" textAlign="center">
-            {usdPrice && smallUsdFormatter(pool.totalBorrowedNative * usdPrice)}
+            {usdPrice && smallUsdFormatter(data.totalBorrowedNative * usdPrice)}
           </Text>
         </VStack>
 
@@ -190,8 +186,8 @@ const PoolRow = ({
                 </Row>
                 <Row crossAxisAlignment="center" mainAxisAlignment="center" width="100%">
                   <Text fontWeight="bold" textAlign="center">
-                    {isMostSupplied
-                      ? fusePoolData && smallUsdFormatter(fusePoolData.totalBorrowBalanceNative)
+                    {isMostSupplied && usdPrice
+                      ? data && smallUsdFormatter(data.totalBorrowBalanceNative * usdPrice)
                       : '$0.00'}
                   </Text>
                 </Row>
@@ -204,8 +200,8 @@ const PoolRow = ({
                 </Row>
                 <Row crossAxisAlignment="center" mainAxisAlignment="center" width="100%">
                   <Text fontWeight="bold" textAlign="center">
-                    {isMostSupplied
-                      ? fusePoolData && smallUsdFormatter(fusePoolData.totalSupplyBalanceFiat)
+                    {isMostSupplied && usdPrice
+                      ? data && smallUsdFormatter(data.totalSupplyBalanceNative * usdPrice)
                       : '$0.00'}
                   </Text>
                 </Row>
@@ -307,24 +303,24 @@ const PoolRow = ({
                   Pool Address
                 </Text>
               </Column>
-              {fusePoolData?.comptroller && (
+              {data.comptroller && (
                 <Column mainAxisAlignment="center" crossAxisAlignment="flex-start">
                   <Row crossAxisAlignment="center" mainAxisAlignment="flex-start">
                     <ClipboardValue
                       fontWeight="bold"
                       textAlign="center"
                       component={Text}
-                      value={fusePoolData?.comptroller}
-                      label={shortAddress(fusePoolData?.comptroller, 4, 4)}
+                      value={data.comptroller}
+                      label={shortAddress(data.comptroller, 4, 4)}
                     />
                     <SimpleTooltip
                       placement="top-start"
-                      label={`${scanUrl}/address/${fusePoolData?.comptroller}`}
+                      label={`${scanUrl}/address/${data.comptroller}`}
                     >
                       <Button
                         variant={'link'}
                         as={ChakraLink}
-                        href={`${scanUrl}/address/${fusePoolData?.comptroller}`}
+                        href={`${scanUrl}/address/${data.comptroller}`}
                         isExternal
                       >
                         <LinkIcon h={{ base: 3, sm: 6 }} />

--- a/packages/ui/hooks/fuse/usePoolSorting.ts
+++ b/packages/ui/hooks/fuse/usePoolSorting.ts
@@ -1,7 +1,13 @@
 import { useMemo } from 'react';
 
-const usePoolSorting = <T>(
-  pools: Array<T & { totalSuppliedNative: number; totalBorrowedNative: number; id: number }>,
+interface SortablePool {
+  id: number;
+  totalBorrowedNative: number;
+  totalSuppliedNative: number;
+}
+
+const usePoolSorting = <T extends SortablePool>(
+  pools: Array<T>,
   sortBy: string | null
 ): Array<T> => {
   return useMemo(() => {

--- a/packages/ui/hooks/fuse/usePoolSorting.ts
+++ b/packages/ui/hooks/fuse/usePoolSorting.ts
@@ -1,9 +1,11 @@
-import { FusePoolData } from '@midas-capital/sdk';
 import { useMemo } from 'react';
 
-const usePoolSorting = (pools: FusePoolData[], sortBy: string | null): FusePoolData[] => {
+const usePoolSorting = <T>(
+  pools: Array<T & { totalSuppliedNative: number; totalBorrowedNative: number; id: number }>,
+  sortBy: string | null
+): Array<T> => {
   return useMemo(() => {
-    pools?.sort((a: FusePoolData, b: FusePoolData) => {
+    pools?.sort((a, b) => {
       if (!sortBy || sortBy.toLowerCase() === 'supply') {
         if (b.totalSuppliedNative > a.totalSuppliedNative) {
           return 1;
@@ -24,7 +26,7 @@ const usePoolSorting = (pools: FusePoolData[], sortBy: string | null): FusePoolD
       return b.id > a.id ? 1 : -1;
     });
 
-    return pools.map((pool: FusePoolData) => pool);
+    return pools.map((pool) => pool);
   }, [pools, sortBy]);
 };
 

--- a/packages/ui/hooks/useFusePoolData.ts
+++ b/packages/ui/hooks/useFusePoolData.ts
@@ -4,39 +4,57 @@ import { useQuery } from 'react-query';
 import { useRari } from '@ui/context/RariContext';
 import { useUSDPrice } from '@ui/hooks/useUSDPrice';
 
+export interface AdaptedFuseAsset extends NativePricedFuseAsset {
+  supplyBalanceFiat: number;
+  borrowBalanceFiat: number;
+  totalSupplyFiat: number;
+  totalBorrowFiat: number;
+  liquidityFiat: number;
+}
+
+export interface AdaptedFusePoolData extends FusePoolData {
+  assets: AdaptedFuseAsset[];
+  totalLiquidityFiat: number;
+  totalSuppliedFiat: number;
+  totalBorrowedFiat: number;
+  totalSupplyBalanceFiat: number;
+  totalBorrowBalanceFiat: number;
+}
+
 export const useFusePoolData = (poolId: string) => {
   const { fuse, currentChain, address, coingeckoId } = useRari();
   const { data: usdPrice } = useUSDPrice(coingeckoId);
 
-  return useQuery<FusePoolData | null>(
+  return useQuery<AdaptedFusePoolData | null>(
     ['useFusePoolData', currentChain.id, poolId, address, usdPrice],
     async () => {
       if (!usdPrice) return null;
 
       const res = await fuse.fetchFusePoolData(poolId, address);
-      const assetsWithPrice: NativePricedFuseAsset[] = [];
+      const assetsWithPrice: AdaptedFuseAsset[] = [];
       if (res.assets && res.assets.length !== 0) {
         res.assets.map((asset) => {
           assetsWithPrice.push({
             ...asset,
-            supplyBalanceNative: asset.supplyBalanceNative * usdPrice,
-            borrowBalanceNative: asset.borrowBalanceNative * usdPrice,
-            totalSupplyNative: asset.totalSupplyNative * usdPrice,
-            totalBorrowNative: asset.totalBorrowNative * usdPrice,
-            liquidityNative: asset.liquidityNative * usdPrice,
+            supplyBalanceFiat: asset.supplyBalanceNative * usdPrice,
+            borrowBalanceFiat: asset.borrowBalanceNative * usdPrice,
+            totalSupplyFiat: asset.totalSupplyNative * usdPrice,
+            totalBorrowFiat: asset.totalBorrowNative * usdPrice,
+            liquidityFiat: asset.liquidityNative * usdPrice,
           });
         });
       }
-
-      return {
+      const adaptedFusePoolData: AdaptedFusePoolData = {
         ...res,
         assets: assetsWithPrice,
-        totalLiquidityNative: res.totalLiquidityNative * usdPrice,
-        totalSuppliedNative: res.totalSuppliedNative * usdPrice,
-        totalBorrowedNative: res.totalBorrowedNative * usdPrice,
-        totalSupplyBalanceNative: res.totalSupplyBalanceNative * usdPrice,
-        totalBorrowBalanceNative: res.totalBorrowBalanceNative * usdPrice,
-      } as FusePoolData;
+        totalLiquidityFiat: res.totalLiquidityNative * usdPrice,
+        totalSuppliedFiat: res.totalSuppliedNative * usdPrice,
+        totalBorrowedFiat: res.totalBorrowedNative * usdPrice,
+        totalSupplyBalanceFiat: res.totalSupplyBalanceNative * usdPrice,
+        totalBorrowBalanceFiat: res.totalBorrowBalanceNative * usdPrice,
+      };
+
+      return adaptedFusePoolData;
     },
     { enabled: !!usdPrice }
   );

--- a/packages/ui/hooks/useFusePoolData.ts
+++ b/packages/ui/hooks/useFusePoolData.ts
@@ -4,7 +4,7 @@ import { useQuery } from 'react-query';
 import { useRari } from '@ui/context/RariContext';
 import { useUSDPrice } from '@ui/hooks/useUSDPrice';
 
-export interface Market extends NativePricedFuseAsset {
+export interface MarketData extends NativePricedFuseAsset {
   supplyBalanceFiat: number;
   borrowBalanceFiat: number;
   totalSupplyFiat: number;
@@ -12,8 +12,8 @@ export interface Market extends NativePricedFuseAsset {
   liquidityFiat: number;
 }
 
-export interface Pool extends SDKFusePoolData {
-  assets: Market[];
+export interface PoolData extends SDKFusePoolData {
+  assets: MarketData[];
   totalLiquidityFiat: number;
   totalSuppliedFiat: number;
   totalBorrowedFiat: number;
@@ -25,13 +25,13 @@ export const useFusePoolData = (poolId: string) => {
   const { fuse, currentChain, address, coingeckoId } = useRari();
   const { data: usdPrice } = useUSDPrice(coingeckoId);
 
-  return useQuery<Pool | null>(
+  return useQuery<PoolData | null>(
     ['useFusePoolData', currentChain.id, poolId, address, usdPrice],
     async () => {
       if (!usdPrice) return null;
 
       const res = await fuse.fetchFusePoolData(poolId, address);
-      const assetsWithPrice: Market[] = [];
+      const assetsWithPrice: MarketData[] = [];
       if (res.assets && res.assets.length !== 0) {
         res.assets.map((asset) => {
           assetsWithPrice.push({
@@ -44,7 +44,7 @@ export const useFusePoolData = (poolId: string) => {
           });
         });
       }
-      const adaptedFusePoolData: FusePoolData = {
+      const adaptedFusePoolData: PoolData = {
         ...res,
         assets: assetsWithPrice,
         totalLiquidityFiat: res.totalLiquidityNative * usdPrice,

--- a/packages/ui/hooks/useFusePoolData.ts
+++ b/packages/ui/hooks/useFusePoolData.ts
@@ -1,10 +1,10 @@
-import { FusePoolData, NativePricedFuseAsset } from '@midas-capital/sdk';
+import { NativePricedFuseAsset, FusePoolData as SDKFusePoolData } from '@midas-capital/sdk';
 import { useQuery } from 'react-query';
 
 import { useRari } from '@ui/context/RariContext';
 import { useUSDPrice } from '@ui/hooks/useUSDPrice';
 
-export interface AdaptedFuseAsset extends NativePricedFuseAsset {
+export interface Market extends NativePricedFuseAsset {
   supplyBalanceFiat: number;
   borrowBalanceFiat: number;
   totalSupplyFiat: number;
@@ -12,8 +12,8 @@ export interface AdaptedFuseAsset extends NativePricedFuseAsset {
   liquidityFiat: number;
 }
 
-export interface AdaptedFusePoolData extends FusePoolData {
-  assets: AdaptedFuseAsset[];
+export interface Pool extends SDKFusePoolData {
+  assets: Market[];
   totalLiquidityFiat: number;
   totalSuppliedFiat: number;
   totalBorrowedFiat: number;
@@ -25,13 +25,13 @@ export const useFusePoolData = (poolId: string) => {
   const { fuse, currentChain, address, coingeckoId } = useRari();
   const { data: usdPrice } = useUSDPrice(coingeckoId);
 
-  return useQuery<AdaptedFusePoolData | null>(
+  return useQuery<Pool | null>(
     ['useFusePoolData', currentChain.id, poolId, address, usdPrice],
     async () => {
       if (!usdPrice) return null;
 
       const res = await fuse.fetchFusePoolData(poolId, address);
-      const assetsWithPrice: AdaptedFuseAsset[] = [];
+      const assetsWithPrice: Market[] = [];
       if (res.assets && res.assets.length !== 0) {
         res.assets.map((asset) => {
           assetsWithPrice.push({
@@ -44,7 +44,7 @@ export const useFusePoolData = (poolId: string) => {
           });
         });
       }
-      const adaptedFusePoolData: AdaptedFusePoolData = {
+      const adaptedFusePoolData: FusePoolData = {
         ...res,
         assets: assetsWithPrice,
         totalLiquidityFiat: res.totalLiquidityNative * usdPrice,

--- a/packages/ui/hooks/useRSS.ts
+++ b/packages/ui/hooks/useRSS.ts
@@ -20,6 +20,11 @@ export const letterScore = (totalScore: number) => {
   return 'UNSAFE';
 };
 
+// TODO REWORK
+// duplicated code from useFusePoolData and it's not even needed!!
+// RSS should be able to be calculated completely in the backend.
+// Quite ridiculous to fetch usd prices and pool data in frontend to just pass it to the backend...
+
 export const usePoolRSS = (poolId: string | number) => {
   const { fuse, currentChain, address, coingeckoId } = useRari();
   const { data: usdPrice } = useUSDPrice(coingeckoId);


### PR DESCRIPTION
We overwrote the `Native` price with the USD price. Super confusing. Now added fields for Fiat prices alongside the Native Price.


Important Part:

https://github.com/Midas-Protocol/monorepo/blob/51c6ac7808121d57700d15afdedc9312646838f2/packages/ui/hooks/useFusePoolData.ts#L7-L22

Still not the best way to do this. It's just a bit less confusing now. Next refactor comes in with new backend api probably.
