### PR TITLE
test for getting difference between asset.borrowRatePerBlock and one …

### DIFF
--- a/packages/ui/components/pages/Fuse/Modals/PoolModal/AmountSelect.tsx
+++ b/packages/ui/components/pages/Fuse/Modals/PoolModal/AmountSelect.tsx
@@ -559,6 +559,22 @@ const StatsColumn = ({ mode, assets, index, amount, enableAsCollateral }: StatsC
     ? utils.commify(utils.formatUnits(updatedAsset.supplyBalance, updatedAsset.underlyingDecimals))
     : '';
 
+  useEffect(() => {
+    const func = async () => {
+      console.log('asset.borrowRatePerBlock: ', asset.borrowRatePerBlock);
+
+      const irm = await fuse.getInterestRateModel(asset.cToken);
+
+      const borrowRatePerBlockByIrm = irm.getBorrowRate(
+        utils.parseUnits((asset.utilization / 100).toFixed(18))
+      ); // this borrowRatePerBlockByIrm should be the same as asset.borrowRatePerBlock but different
+
+      console.log('borrowRatePerBlockByIrm: ', borrowRatePerBlockByIrm);
+    };
+
+    func();
+  });
+
   return (
     <DashboardBox width="100%" height="190px" mt={4}>
       {updatedAsset ? (


### PR DESCRIPTION
While I am trying to debug this issue https://github.com/Midas-Protocol/monorepo/issues/255, I found that `borrowRatePerBlock`s from asset's property and from irm were different.

See my logs 

![image](https://user-images.githubusercontent.com/45715420/176861656-5f055e2e-0fd7-487a-bced-1b3a911a8b7c.png)

`borrowRatePerBlockByIrm` should be the same as `asset.borrowRatePerBlock` but different