### PR TITLE
fix issue with maxAmount calculation

### DIFF
--- a/packages/ui/components/pages/Fuse/Modals/PoolModal/AmountSelect.tsx
+++ b/packages/ui/components/pages/Fuse/Modals/PoolModal/AmountSelect.tsx
@@ -130,9 +130,9 @@ const AmountSelect = ({
   const updateMaxBNAmount = (bNAmount: BigNumber) => {
     const str = utils.formatUnits(bNAmount, asset.underlyingDecimals);
     _setUserEnteredAmount(str);
-    _setAmount(bNAmount)
+    _setAmount(bNAmount);
     setUserAction(UserAction.NO_ACTION);
-  }
+  };
 
   const { data: amountIsValid } = useQuery(['ValidAmount', mode, amount], async () => {
     if (amount === null || amount.isZero()) {
@@ -325,7 +325,11 @@ const AmountSelect = ({
                     disabled={isBorrowPaused}
                     autoFocus
                   />
-                  <TokenNameAndMaxButton mode={mode} asset={asset} updateMaxBNAmount={updateMaxBNAmount} />
+                  <TokenNameAndMaxButton
+                    mode={mode}
+                    asset={asset}
+                    updateMaxBNAmount={updateMaxBNAmount}
+                  />
                 </Row>
               </DashboardBox>
               {mode === FundOperationMode.BORROW && borrowableAmount + borrowedAmount !== 0 && (

--- a/packages/ui/components/pages/Fuse/Modals/PoolModal/AmountSelect.tsx
+++ b/packages/ui/components/pages/Fuse/Modals/PoolModal/AmountSelect.tsx
@@ -127,6 +127,13 @@ const AmountSelect = ({
     setUserAction(UserAction.NO_ACTION);
   };
 
+  const updateMaxBNAmount = (bNAmount: BigNumber) => {
+    const str = utils.formatUnits(bNAmount, asset.underlyingDecimals);
+    _setUserEnteredAmount(str);
+    _setAmount(bNAmount)
+    setUserAction(UserAction.NO_ACTION);
+  }
+
   const { data: amountIsValid } = useQuery(['ValidAmount', mode, amount], async () => {
     if (amount === null || amount.isZero()) {
       return false;
@@ -318,7 +325,7 @@ const AmountSelect = ({
                     disabled={isBorrowPaused}
                     autoFocus
                   />
-                  <TokenNameAndMaxButton mode={mode} asset={asset} updateAmount={updateAmount} />
+                  <TokenNameAndMaxButton mode={mode} asset={asset} updateMaxBNAmount={updateMaxBNAmount} />
                 </Row>
               </DashboardBox>
               {mode === FundOperationMode.BORROW && borrowableAmount + borrowedAmount !== 0 && (
@@ -657,13 +664,13 @@ const StatsColumn = ({ mode, assets, index, amount, enableAsCollateral }: StatsC
 };
 
 const TokenNameAndMaxButton = ({
-  updateAmount,
+  updateMaxBNAmount,
   asset,
   mode,
 }: {
   asset: NativePricedFuseAsset;
   mode: FundOperationMode;
-  updateAmount: (newAmount: string) => void;
+  updateMaxBNAmount: (newAmount: BigNumber) => void;
 }) => {
   const { fuse, address } = useRari();
 
@@ -678,10 +685,9 @@ const TokenNameAndMaxButton = ({
       const maxBN = (await fetchMaxAmount(mode, fuse, address, asset)) as BigNumber;
 
       if (maxBN.lt(constants.Zero) || maxBN.isZero()) {
-        updateAmount('');
+        updateMaxBNAmount(constants.Zero);
       } else {
-        const str = utils.formatUnits(maxBN, asset.underlyingDecimals);
-        updateAmount(str);
+        updateMaxBNAmount(maxBN);
       }
 
       setIsMaxLoading(false);


### PR DESCRIPTION
## Description

Fix max withdraw issue and other potential rounding issue

## Type of change

- [ ] Docs change / dependency upgrade
- [ ] Configuration / tooling changes
- [ ] Refactoring
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Requires changes in customer code

## High-level change(s) description - from the user's perspective

The issue comes with managing max Amount. Current logic is converting fetched maxAmount big Number to string value and change that to big Number again on Confirm click. At this point there is tiny difference by rounding issue.
For max button case, we removed coverting process and use fetched maxAmount directly on final Confirm.

## Related Issue(s)

Fixes [the issue](https://github.com/Midas-Protocol/monorepo/issues/259)
