### PR TITLE
Save Plugin instead of Market Address

### DIFF
--- a/.env.dist
+++ b/.env.dist
@@ -1,0 +1,3 @@
+SUPABASE_KEY=
+SUPABASE_PLUGIN_TABLE_NAME=apy-plugin-development
+SUPABASE_FLYWHEEL_TABLE_NAME=apy-flywheel-development

--- a/packages/functions/src/abi/ctoken.json
+++ b/packages/functions/src/abi/ctoken.json
@@ -1,29 +1,34 @@
 [
   {
+    "anonymous": false,
     "inputs": [
       {
-        "internalType": "contract ERC20",
-        "name": "_asset",
-        "type": "address"
+        "indexed": false,
+        "internalType": "uint256",
+        "name": "cashPrior",
+        "type": "uint256"
       },
       {
-        "internalType": "contract FlywheelCore",
-        "name": "_dddFlywheel",
-        "type": "address"
+        "indexed": false,
+        "internalType": "uint256",
+        "name": "interestAccumulated",
+        "type": "uint256"
       },
       {
-        "internalType": "contract FlywheelCore",
-        "name": "_epxFlywheel",
-        "type": "address"
+        "indexed": false,
+        "internalType": "uint256",
+        "name": "borrowIndex",
+        "type": "uint256"
       },
       {
-        "internalType": "contract ILpDepositor",
-        "name": "_lpDepositor",
-        "type": "address"
+        "indexed": false,
+        "internalType": "uint256",
+        "name": "totalBorrows",
+        "type": "uint256"
       }
     ],
-    "stateMutability": "nonpayable",
-    "type": "constructor"
+    "name": "AccrueInterest",
+    "type": "event"
   },
   {
     "anonymous": false,
@@ -54,31 +59,363 @@
     "anonymous": false,
     "inputs": [
       {
-        "indexed": true,
+        "indexed": false,
         "internalType": "address",
-        "name": "caller",
-        "type": "address"
-      },
-      {
-        "indexed": true,
-        "internalType": "address",
-        "name": "owner",
+        "name": "borrower",
         "type": "address"
       },
       {
         "indexed": false,
         "internalType": "uint256",
-        "name": "assets",
+        "name": "borrowAmount",
         "type": "uint256"
       },
       {
         "indexed": false,
         "internalType": "uint256",
-        "name": "shares",
+        "name": "accountBorrows",
+        "type": "uint256"
+      },
+      {
+        "indexed": false,
+        "internalType": "uint256",
+        "name": "totalBorrows",
         "type": "uint256"
       }
     ],
-    "name": "Deposit",
+    "name": "Borrow",
+    "type": "event"
+  },
+  {
+    "anonymous": false,
+    "inputs": [
+      {
+        "indexed": false,
+        "internalType": "uint256",
+        "name": "error",
+        "type": "uint256"
+      },
+      {
+        "indexed": false,
+        "internalType": "uint256",
+        "name": "info",
+        "type": "uint256"
+      },
+      {
+        "indexed": false,
+        "internalType": "uint256",
+        "name": "detail",
+        "type": "uint256"
+      }
+    ],
+    "name": "Failure",
+    "type": "event"
+  },
+  {
+    "anonymous": false,
+    "inputs": [
+      {
+        "indexed": false,
+        "internalType": "address",
+        "name": "liquidator",
+        "type": "address"
+      },
+      {
+        "indexed": false,
+        "internalType": "address",
+        "name": "borrower",
+        "type": "address"
+      },
+      {
+        "indexed": false,
+        "internalType": "uint256",
+        "name": "repayAmount",
+        "type": "uint256"
+      },
+      {
+        "indexed": false,
+        "internalType": "address",
+        "name": "cTokenCollateral",
+        "type": "address"
+      },
+      {
+        "indexed": false,
+        "internalType": "uint256",
+        "name": "seizeTokens",
+        "type": "uint256"
+      }
+    ],
+    "name": "LiquidateBorrow",
+    "type": "event"
+  },
+  {
+    "anonymous": false,
+    "inputs": [
+      {
+        "indexed": false,
+        "internalType": "address",
+        "name": "minter",
+        "type": "address"
+      },
+      {
+        "indexed": false,
+        "internalType": "uint256",
+        "name": "mintAmount",
+        "type": "uint256"
+      },
+      {
+        "indexed": false,
+        "internalType": "uint256",
+        "name": "mintTokens",
+        "type": "uint256"
+      }
+    ],
+    "name": "Mint",
+    "type": "event"
+  },
+  {
+    "anonymous": false,
+    "inputs": [
+      {
+        "indexed": false,
+        "internalType": "uint256",
+        "name": "oldAdminFeeMantissa",
+        "type": "uint256"
+      },
+      {
+        "indexed": false,
+        "internalType": "uint256",
+        "name": "newAdminFeeMantissa",
+        "type": "uint256"
+      }
+    ],
+    "name": "NewAdminFee",
+    "type": "event"
+  },
+  {
+    "anonymous": false,
+    "inputs": [
+      {
+        "indexed": false,
+        "internalType": "contract ComptrollerInterface",
+        "name": "oldComptroller",
+        "type": "address"
+      },
+      {
+        "indexed": false,
+        "internalType": "contract ComptrollerInterface",
+        "name": "newComptroller",
+        "type": "address"
+      }
+    ],
+    "name": "NewComptroller",
+    "type": "event"
+  },
+  {
+    "anonymous": false,
+    "inputs": [
+      {
+        "indexed": false,
+        "internalType": "uint256",
+        "name": "oldFuseFeeMantissa",
+        "type": "uint256"
+      },
+      {
+        "indexed": false,
+        "internalType": "uint256",
+        "name": "newFuseFeeMantissa",
+        "type": "uint256"
+      }
+    ],
+    "name": "NewFuseFee",
+    "type": "event"
+  },
+  {
+    "anonymous": false,
+    "inputs": [
+      {
+        "indexed": false,
+        "internalType": "address",
+        "name": "oldImplementation",
+        "type": "address"
+      },
+      {
+        "indexed": false,
+        "internalType": "address",
+        "name": "newImplementation",
+        "type": "address"
+      }
+    ],
+    "name": "NewImplementation",
+    "type": "event"
+  },
+  {
+    "anonymous": false,
+    "inputs": [
+      {
+        "indexed": false,
+        "internalType": "contract InterestRateModel",
+        "name": "oldInterestRateModel",
+        "type": "address"
+      },
+      {
+        "indexed": false,
+        "internalType": "contract InterestRateModel",
+        "name": "newInterestRateModel",
+        "type": "address"
+      }
+    ],
+    "name": "NewMarketInterestRateModel",
+    "type": "event"
+  },
+  {
+    "anonymous": false,
+    "inputs": [
+      {
+        "indexed": false,
+        "internalType": "address",
+        "name": "oldImpl",
+        "type": "address"
+      },
+      {
+        "indexed": false,
+        "internalType": "address",
+        "name": "newImpl",
+        "type": "address"
+      }
+    ],
+    "name": "NewPluginImplementation",
+    "type": "event"
+  },
+  {
+    "anonymous": false,
+    "inputs": [
+      {
+        "indexed": false,
+        "internalType": "uint256",
+        "name": "oldReserveFactorMantissa",
+        "type": "uint256"
+      },
+      {
+        "indexed": false,
+        "internalType": "uint256",
+        "name": "newReserveFactorMantissa",
+        "type": "uint256"
+      }
+    ],
+    "name": "NewReserveFactor",
+    "type": "event"
+  },
+  {
+    "anonymous": false,
+    "inputs": [
+      {
+        "indexed": false,
+        "internalType": "address",
+        "name": "redeemer",
+        "type": "address"
+      },
+      {
+        "indexed": false,
+        "internalType": "uint256",
+        "name": "redeemAmount",
+        "type": "uint256"
+      },
+      {
+        "indexed": false,
+        "internalType": "uint256",
+        "name": "redeemTokens",
+        "type": "uint256"
+      }
+    ],
+    "name": "Redeem",
+    "type": "event"
+  },
+  {
+    "anonymous": false,
+    "inputs": [
+      {
+        "indexed": false,
+        "internalType": "address",
+        "name": "payer",
+        "type": "address"
+      },
+      {
+        "indexed": false,
+        "internalType": "address",
+        "name": "borrower",
+        "type": "address"
+      },
+      {
+        "indexed": false,
+        "internalType": "uint256",
+        "name": "repayAmount",
+        "type": "uint256"
+      },
+      {
+        "indexed": false,
+        "internalType": "uint256",
+        "name": "accountBorrows",
+        "type": "uint256"
+      },
+      {
+        "indexed": false,
+        "internalType": "uint256",
+        "name": "totalBorrows",
+        "type": "uint256"
+      }
+    ],
+    "name": "RepayBorrow",
+    "type": "event"
+  },
+  {
+    "anonymous": false,
+    "inputs": [
+      {
+        "indexed": false,
+        "internalType": "address",
+        "name": "benefactor",
+        "type": "address"
+      },
+      {
+        "indexed": false,
+        "internalType": "uint256",
+        "name": "addAmount",
+        "type": "uint256"
+      },
+      {
+        "indexed": false,
+        "internalType": "uint256",
+        "name": "newTotalReserves",
+        "type": "uint256"
+      }
+    ],
+    "name": "ReservesAdded",
+    "type": "event"
+  },
+  {
+    "anonymous": false,
+    "inputs": [
+      {
+        "indexed": false,
+        "internalType": "address",
+        "name": "admin",
+        "type": "address"
+      },
+      {
+        "indexed": false,
+        "internalType": "uint256",
+        "name": "reduceAmount",
+        "type": "uint256"
+      },
+      {
+        "indexed": false,
+        "internalType": "uint256",
+        "name": "newTotalReserves",
+        "type": "uint256"
+      }
+    ],
+    "name": "ReservesReduced",
     "type": "event"
   },
   {
@@ -107,50 +444,221 @@
     "type": "event"
   },
   {
-    "anonymous": false,
-    "inputs": [
+    "inputs": [],
+    "name": "PRECISION",
+    "outputs": [
       {
-        "indexed": true,
-        "internalType": "address",
-        "name": "caller",
-        "type": "address"
-      },
-      {
-        "indexed": true,
-        "internalType": "address",
-        "name": "receiver",
-        "type": "address"
-      },
-      {
-        "indexed": true,
-        "internalType": "address",
-        "name": "owner",
-        "type": "address"
-      },
-      {
-        "indexed": false,
         "internalType": "uint256",
-        "name": "assets",
-        "type": "uint256"
-      },
-      {
-        "indexed": false,
-        "internalType": "uint256",
-        "name": "shares",
+        "name": "",
         "type": "uint256"
       }
     ],
-    "name": "Withdraw",
-    "type": "event"
+    "stateMutability": "view",
+    "type": "function"
+  },
+  {
+    "inputs": [
+      {
+        "internalType": "bytes",
+        "name": "data",
+        "type": "bytes"
+      }
+    ],
+    "name": "_becomeImplementation",
+    "outputs": [],
+    "stateMutability": "nonpayable",
+    "type": "function"
   },
   {
     "inputs": [],
-    "name": "DOMAIN_SEPARATOR",
+    "name": "_prepare",
+    "outputs": [],
+    "stateMutability": "payable",
+    "type": "function"
+  },
+  {
+    "inputs": [
+      {
+        "internalType": "uint256",
+        "name": "newAdminFeeMantissa",
+        "type": "uint256"
+      }
+    ],
+    "name": "_setAdminFee",
     "outputs": [
       {
-        "internalType": "bytes32",
+        "internalType": "uint256",
         "name": "",
-        "type": "bytes32"
+        "type": "uint256"
+      }
+    ],
+    "stateMutability": "nonpayable",
+    "type": "function"
+  },
+  {
+    "inputs": [
+      {
+        "internalType": "address",
+        "name": "implementation_",
+        "type": "address"
+      },
+      {
+        "internalType": "bool",
+        "name": "allowResign",
+        "type": "bool"
+      },
+      {
+        "internalType": "bytes",
+        "name": "becomeImplementationData",
+        "type": "bytes"
+      }
+    ],
+    "name": "_setImplementationSafe",
+    "outputs": [],
+    "stateMutability": "nonpayable",
+    "type": "function"
+  },
+  {
+    "inputs": [
+      {
+        "internalType": "contract InterestRateModel",
+        "name": "newInterestRateModel",
+        "type": "address"
+      }
+    ],
+    "name": "_setInterestRateModel",
+    "outputs": [
+      {
+        "internalType": "uint256",
+        "name": "",
+        "type": "uint256"
+      }
+    ],
+    "stateMutability": "nonpayable",
+    "type": "function"
+  },
+  {
+    "inputs": [
+      {
+        "internalType": "string",
+        "name": "_name",
+        "type": "string"
+      },
+      {
+        "internalType": "string",
+        "name": "_symbol",
+        "type": "string"
+      }
+    ],
+    "name": "_setNameAndSymbol",
+    "outputs": [],
+    "stateMutability": "nonpayable",
+    "type": "function"
+  },
+  {
+    "inputs": [
+      {
+        "internalType": "uint256",
+        "name": "newReserveFactorMantissa",
+        "type": "uint256"
+      }
+    ],
+    "name": "_setReserveFactor",
+    "outputs": [
+      {
+        "internalType": "uint256",
+        "name": "",
+        "type": "uint256"
+      }
+    ],
+    "stateMutability": "nonpayable",
+    "type": "function"
+  },
+  {
+    "inputs": [
+      {
+        "internalType": "address",
+        "name": "_plugin",
+        "type": "address"
+      }
+    ],
+    "name": "_updatePlugin",
+    "outputs": [],
+    "stateMutability": "nonpayable",
+    "type": "function"
+  },
+  {
+    "inputs": [
+      {
+        "internalType": "uint256",
+        "name": "withdrawAmount",
+        "type": "uint256"
+      }
+    ],
+    "name": "_withdrawAdminFees",
+    "outputs": [
+      {
+        "internalType": "uint256",
+        "name": "",
+        "type": "uint256"
+      }
+    ],
+    "stateMutability": "nonpayable",
+    "type": "function"
+  },
+  {
+    "inputs": [
+      {
+        "internalType": "uint256",
+        "name": "withdrawAmount",
+        "type": "uint256"
+      }
+    ],
+    "name": "_withdrawFuseFees",
+    "outputs": [
+      {
+        "internalType": "uint256",
+        "name": "",
+        "type": "uint256"
+      }
+    ],
+    "stateMutability": "nonpayable",
+    "type": "function"
+  },
+  {
+    "inputs": [],
+    "name": "accrualBlockNumber",
+    "outputs": [
+      {
+        "internalType": "uint256",
+        "name": "",
+        "type": "uint256"
+      }
+    ],
+    "stateMutability": "view",
+    "type": "function"
+  },
+  {
+    "inputs": [],
+    "name": "accrueInterest",
+    "outputs": [
+      {
+        "internalType": "uint256",
+        "name": "",
+        "type": "uint256"
+      }
+    ],
+    "stateMutability": "nonpayable",
+    "type": "function"
+  },
+  {
+    "inputs": [],
+    "name": "adminFeeMantissa",
+    "outputs": [
+      {
+        "internalType": "uint256",
+        "name": "",
+        "type": "uint256"
       }
     ],
     "stateMutability": "view",
@@ -160,12 +668,12 @@
     "inputs": [
       {
         "internalType": "address",
-        "name": "",
+        "name": "owner",
         "type": "address"
       },
       {
         "internalType": "address",
-        "name": "",
+        "name": "spender",
         "type": "address"
       }
     ],
@@ -205,55 +713,28 @@
     "type": "function"
   },
   {
-    "inputs": [],
-    "name": "asset",
-    "outputs": [
-      {
-        "internalType": "contract ERC20",
-        "name": "",
-        "type": "address"
-      }
-    ],
-    "stateMutability": "view",
-    "type": "function"
-  },
-  {
-    "inputs": [],
-    "name": "underlying",
-    "outputs": [
-      {
-        "internalType": "address",
-        "name": "",
-        "type": "address"
-      }
-    ],
-    "stateMutability": "view",
-    "type": "function"
-  },
-  {
     "inputs": [
       {
-        "internalType": "uint256",
-        "name": "",
-        "type": "uint256"
-      }
-    ],
-    "name": "assetAsArray",
-    "outputs": [
+        "internalType": "address",
+        "name": "_token",
+        "type": "address"
+      },
       {
         "internalType": "address",
-        "name": "",
+        "name": "_spender",
         "type": "address"
       }
     ],
-    "stateMutability": "view",
+    "name": "approve",
+    "outputs": [],
+    "stateMutability": "nonpayable",
     "type": "function"
   },
   {
     "inputs": [
       {
         "internalType": "address",
-        "name": "",
+        "name": "owner",
         "type": "address"
       }
     ],
@@ -272,7 +753,7 @@
     "inputs": [
       {
         "internalType": "address",
-        "name": "account",
+        "name": "owner",
         "type": "address"
       }
     ],
@@ -284,18 +765,18 @@
         "type": "uint256"
       }
     ],
-    "stateMutability": "view",
+    "stateMutability": "nonpayable",
     "type": "function"
   },
   {
     "inputs": [
       {
         "internalType": "uint256",
-        "name": "shares",
+        "name": "borrowAmount",
         "type": "uint256"
       }
     ],
-    "name": "convertToAssets",
+    "name": "borrow",
     "outputs": [
       {
         "internalType": "uint256",
@@ -303,18 +784,37 @@
         "type": "uint256"
       }
     ],
-    "stateMutability": "view",
+    "stateMutability": "nonpayable",
     "type": "function"
   },
   {
     "inputs": [
       {
+        "internalType": "address",
+        "name": "account",
+        "type": "address"
+      }
+    ],
+    "name": "borrowBalanceCurrent",
+    "outputs": [
+      {
         "internalType": "uint256",
-        "name": "assets",
+        "name": "",
         "type": "uint256"
       }
     ],
-    "name": "convertToShares",
+    "stateMutability": "nonpayable",
+    "type": "function"
+  },
+  {
+    "inputs": [
+      {
+        "internalType": "address",
+        "name": "account",
+        "type": "address"
+      }
+    ],
+    "name": "borrowBalanceStored",
     "outputs": [
       {
         "internalType": "uint256",
@@ -327,10 +827,43 @@
   },
   {
     "inputs": [],
-    "name": "dddFlywheel",
+    "name": "borrowIndex",
     "outputs": [
       {
-        "internalType": "contract FlywheelCore",
+        "internalType": "uint256",
+        "name": "",
+        "type": "uint256"
+      }
+    ],
+    "stateMutability": "view",
+    "type": "function"
+  },
+  {
+    "inputs": [],
+    "name": "borrowRatePerBlock",
+    "outputs": [
+      {
+        "internalType": "uint256",
+        "name": "",
+        "type": "uint256"
+      }
+    ],
+    "stateMutability": "view",
+    "type": "function"
+  },
+  {
+    "inputs": [],
+    "name": "claim",
+    "outputs": [],
+    "stateMutability": "nonpayable",
+    "type": "function"
+  },
+  {
+    "inputs": [],
+    "name": "comptroller",
+    "outputs": [
+      {
+        "internalType": "contract ComptrollerInterface",
         "name": "",
         "type": "address"
       }
@@ -352,23 +885,12 @@
     "type": "function"
   },
   {
-    "inputs": [
-      {
-        "internalType": "uint256",
-        "name": "assets",
-        "type": "uint256"
-      },
-      {
-        "internalType": "address",
-        "name": "receiver",
-        "type": "address"
-      }
-    ],
-    "name": "deposit",
+    "inputs": [],
+    "name": "exchangeRateCurrent",
     "outputs": [
       {
         "internalType": "uint256",
-        "name": "shares",
+        "name": "",
         "type": "uint256"
       }
     ],
@@ -377,10 +899,36 @@
   },
   {
     "inputs": [],
-    "name": "epxFlywheel",
+    "name": "exchangeRateStored",
     "outputs": [
       {
-        "internalType": "contract FlywheelCore",
+        "internalType": "uint256",
+        "name": "",
+        "type": "uint256"
+      }
+    ],
+    "stateMutability": "view",
+    "type": "function"
+  },
+  {
+    "inputs": [],
+    "name": "feeSeizeShareMantissa",
+    "outputs": [
+      {
+        "internalType": "uint256",
+        "name": "",
+        "type": "uint256"
+      }
+    ],
+    "stateMutability": "view",
+    "type": "function"
+  },
+  {
+    "inputs": [],
+    "name": "fuseAdmin",
+    "outputs": [
+      {
+        "internalType": "address payable",
         "name": "",
         "type": "address"
       }
@@ -390,26 +938,7 @@
   },
   {
     "inputs": [],
-    "name": "lpDepositor",
-    "outputs": [
-      {
-        "internalType": "contract ILpDepositor",
-        "name": "",
-        "type": "address"
-      }
-    ],
-    "stateMutability": "view",
-    "type": "function"
-  },
-  {
-    "inputs": [
-      {
-        "internalType": "address",
-        "name": "",
-        "type": "address"
-      }
-    ],
-    "name": "maxDeposit",
+    "name": "fuseFeeMantissa",
     "outputs": [
       {
         "internalType": "uint256",
@@ -424,77 +953,244 @@
     "inputs": [
       {
         "internalType": "address",
-        "name": "",
+        "name": "account",
         "type": "address"
       }
     ],
-    "name": "maxMint",
+    "name": "getAccountSnapshot",
     "outputs": [
       {
         "internalType": "uint256",
         "name": "",
-        "type": "uint256"
-      }
-    ],
-    "stateMutability": "view",
-    "type": "function"
-  },
-  {
-    "inputs": [
-      {
-        "internalType": "address",
-        "name": "owner",
-        "type": "address"
-      }
-    ],
-    "name": "maxRedeem",
-    "outputs": [
-      {
-        "internalType": "uint256",
-        "name": "",
-        "type": "uint256"
-      }
-    ],
-    "stateMutability": "view",
-    "type": "function"
-  },
-  {
-    "inputs": [
-      {
-        "internalType": "address",
-        "name": "owner",
-        "type": "address"
-      }
-    ],
-    "name": "maxWithdraw",
-    "outputs": [
-      {
-        "internalType": "uint256",
-        "name": "",
-        "type": "uint256"
-      }
-    ],
-    "stateMutability": "view",
-    "type": "function"
-  },
-  {
-    "inputs": [
-      {
-        "internalType": "uint256",
-        "name": "shares",
         "type": "uint256"
       },
       {
+        "internalType": "uint256",
+        "name": "",
+        "type": "uint256"
+      },
+      {
+        "internalType": "uint256",
+        "name": "",
+        "type": "uint256"
+      },
+      {
+        "internalType": "uint256",
+        "name": "",
+        "type": "uint256"
+      }
+    ],
+    "stateMutability": "view",
+    "type": "function"
+  },
+  {
+    "inputs": [],
+    "name": "getCash",
+    "outputs": [
+      {
+        "internalType": "uint256",
+        "name": "",
+        "type": "uint256"
+      }
+    ],
+    "stateMutability": "view",
+    "type": "function"
+  },
+  {
+    "inputs": [],
+    "name": "implementation",
+    "outputs": [
+      {
         "internalType": "address",
-        "name": "receiver",
+        "name": "",
         "type": "address"
+      }
+    ],
+    "stateMutability": "view",
+    "type": "function"
+  },
+  {
+    "inputs": [
+      {
+        "internalType": "address",
+        "name": "underlying_",
+        "type": "address"
+      },
+      {
+        "internalType": "contract ComptrollerInterface",
+        "name": "comptroller_",
+        "type": "address"
+      },
+      {
+        "internalType": "address payable",
+        "name": "fuseAdmin_",
+        "type": "address"
+      },
+      {
+        "internalType": "contract InterestRateModel",
+        "name": "interestRateModel_",
+        "type": "address"
+      },
+      {
+        "internalType": "string",
+        "name": "name_",
+        "type": "string"
+      },
+      {
+        "internalType": "string",
+        "name": "symbol_",
+        "type": "string"
+      },
+      {
+        "internalType": "uint256",
+        "name": "reserveFactorMantissa_",
+        "type": "uint256"
+      },
+      {
+        "internalType": "uint256",
+        "name": "adminFeeMantissa_",
+        "type": "uint256"
+      }
+    ],
+    "name": "initialize",
+    "outputs": [],
+    "stateMutability": "nonpayable",
+    "type": "function"
+  },
+  {
+    "inputs": [
+      {
+        "internalType": "contract ComptrollerInterface",
+        "name": "comptroller_",
+        "type": "address"
+      },
+      {
+        "internalType": "address payable",
+        "name": "fuseAdmin_",
+        "type": "address"
+      },
+      {
+        "internalType": "contract InterestRateModel",
+        "name": "interestRateModel_",
+        "type": "address"
+      },
+      {
+        "internalType": "uint256",
+        "name": "initialExchangeRateMantissa_",
+        "type": "uint256"
+      },
+      {
+        "internalType": "string",
+        "name": "name_",
+        "type": "string"
+      },
+      {
+        "internalType": "string",
+        "name": "symbol_",
+        "type": "string"
+      },
+      {
+        "internalType": "uint8",
+        "name": "decimals_",
+        "type": "uint8"
+      },
+      {
+        "internalType": "uint256",
+        "name": "reserveFactorMantissa_",
+        "type": "uint256"
+      },
+      {
+        "internalType": "uint256",
+        "name": "adminFeeMantissa_",
+        "type": "uint256"
+      }
+    ],
+    "name": "initialize",
+    "outputs": [],
+    "stateMutability": "nonpayable",
+    "type": "function"
+  },
+  {
+    "inputs": [],
+    "name": "interestRateModel",
+    "outputs": [
+      {
+        "internalType": "contract InterestRateModel",
+        "name": "",
+        "type": "address"
+      }
+    ],
+    "stateMutability": "view",
+    "type": "function"
+  },
+  {
+    "inputs": [],
+    "name": "isCEther",
+    "outputs": [
+      {
+        "internalType": "bool",
+        "name": "",
+        "type": "bool"
+      }
+    ],
+    "stateMutability": "nonpayable",
+    "type": "function"
+  },
+  {
+    "inputs": [],
+    "name": "isCToken",
+    "outputs": [
+      {
+        "internalType": "bool",
+        "name": "",
+        "type": "bool"
+      }
+    ],
+    "stateMutability": "nonpayable",
+    "type": "function"
+  },
+  {
+    "inputs": [
+      {
+        "internalType": "address",
+        "name": "borrower",
+        "type": "address"
+      },
+      {
+        "internalType": "uint256",
+        "name": "repayAmount",
+        "type": "uint256"
+      },
+      {
+        "internalType": "contract CTokenInterface",
+        "name": "cTokenCollateral",
+        "type": "address"
+      }
+    ],
+    "name": "liquidateBorrow",
+    "outputs": [
+      {
+        "internalType": "uint256",
+        "name": "",
+        "type": "uint256"
+      }
+    ],
+    "stateMutability": "nonpayable",
+    "type": "function"
+  },
+  {
+    "inputs": [
+      {
+        "internalType": "uint256",
+        "name": "mintAmount",
+        "type": "uint256"
       }
     ],
     "name": "mint",
     "outputs": [
       {
         "internalType": "uint256",
-        "name": "assets",
+        "name": "",
         "type": "uint256"
       }
     ],
@@ -515,76 +1211,21 @@
     "type": "function"
   },
   {
-    "inputs": [
-      {
-        "internalType": "address",
-        "name": "",
-        "type": "address"
-      }
-    ],
-    "name": "nonces",
+    "inputs": [],
+    "name": "plugin",
     "outputs": [
       {
-        "internalType": "uint256",
+        "internalType": "contract IERC4626",
         "name": "",
-        "type": "uint256"
+        "type": "address"
       }
     ],
     "stateMutability": "view",
     "type": "function"
   },
   {
-    "inputs": [
-      {
-        "internalType": "address",
-        "name": "owner",
-        "type": "address"
-      },
-      {
-        "internalType": "address",
-        "name": "spender",
-        "type": "address"
-      },
-      {
-        "internalType": "uint256",
-        "name": "value",
-        "type": "uint256"
-      },
-      {
-        "internalType": "uint256",
-        "name": "deadline",
-        "type": "uint256"
-      },
-      {
-        "internalType": "uint8",
-        "name": "v",
-        "type": "uint8"
-      },
-      {
-        "internalType": "bytes32",
-        "name": "r",
-        "type": "bytes32"
-      },
-      {
-        "internalType": "bytes32",
-        "name": "s",
-        "type": "bytes32"
-      }
-    ],
-    "name": "permit",
-    "outputs": [],
-    "stateMutability": "nonpayable",
-    "type": "function"
-  },
-  {
-    "inputs": [
-      {
-        "internalType": "uint256",
-        "name": "assets",
-        "type": "uint256"
-      }
-    ],
-    "name": "previewDeposit",
+    "inputs": [],
+    "name": "protocolSeizeShareMantissa",
     "outputs": [
       {
         "internalType": "uint256",
@@ -599,86 +1240,136 @@
     "inputs": [
       {
         "internalType": "uint256",
-        "name": "shares",
+        "name": "redeemTokens",
         "type": "uint256"
-      }
-    ],
-    "name": "previewMint",
-    "outputs": [
-      {
-        "internalType": "uint256",
-        "name": "",
-        "type": "uint256"
-      }
-    ],
-    "stateMutability": "view",
-    "type": "function"
-  },
-  {
-    "inputs": [
-      {
-        "internalType": "uint256",
-        "name": "shares",
-        "type": "uint256"
-      }
-    ],
-    "name": "previewRedeem",
-    "outputs": [
-      {
-        "internalType": "uint256",
-        "name": "",
-        "type": "uint256"
-      }
-    ],
-    "stateMutability": "view",
-    "type": "function"
-  },
-  {
-    "inputs": [
-      {
-        "internalType": "uint256",
-        "name": "assets",
-        "type": "uint256"
-      }
-    ],
-    "name": "previewWithdraw",
-    "outputs": [
-      {
-        "internalType": "uint256",
-        "name": "",
-        "type": "uint256"
-      }
-    ],
-    "stateMutability": "view",
-    "type": "function"
-  },
-  {
-    "inputs": [
-      {
-        "internalType": "uint256",
-        "name": "shares",
-        "type": "uint256"
-      },
-      {
-        "internalType": "address",
-        "name": "receiver",
-        "type": "address"
-      },
-      {
-        "internalType": "address",
-        "name": "owner",
-        "type": "address"
       }
     ],
     "name": "redeem",
     "outputs": [
       {
         "internalType": "uint256",
-        "name": "assets",
+        "name": "",
         "type": "uint256"
       }
     ],
     "stateMutability": "nonpayable",
+    "type": "function"
+  },
+  {
+    "inputs": [
+      {
+        "internalType": "uint256",
+        "name": "redeemAmount",
+        "type": "uint256"
+      }
+    ],
+    "name": "redeemUnderlying",
+    "outputs": [
+      {
+        "internalType": "uint256",
+        "name": "",
+        "type": "uint256"
+      }
+    ],
+    "stateMutability": "nonpayable",
+    "type": "function"
+  },
+  {
+    "inputs": [
+      {
+        "internalType": "uint256",
+        "name": "repayAmount",
+        "type": "uint256"
+      }
+    ],
+    "name": "repayBorrow",
+    "outputs": [
+      {
+        "internalType": "uint256",
+        "name": "",
+        "type": "uint256"
+      }
+    ],
+    "stateMutability": "nonpayable",
+    "type": "function"
+  },
+  {
+    "inputs": [
+      {
+        "internalType": "address",
+        "name": "borrower",
+        "type": "address"
+      },
+      {
+        "internalType": "uint256",
+        "name": "repayAmount",
+        "type": "uint256"
+      }
+    ],
+    "name": "repayBorrowBehalf",
+    "outputs": [
+      {
+        "internalType": "uint256",
+        "name": "",
+        "type": "uint256"
+      }
+    ],
+    "stateMutability": "nonpayable",
+    "type": "function"
+  },
+  {
+    "inputs": [],
+    "name": "reserveFactorMantissa",
+    "outputs": [
+      {
+        "internalType": "uint256",
+        "name": "",
+        "type": "uint256"
+      }
+    ],
+    "stateMutability": "view",
+    "type": "function"
+  },
+  {
+    "inputs": [
+      {
+        "internalType": "address",
+        "name": "liquidator",
+        "type": "address"
+      },
+      {
+        "internalType": "address",
+        "name": "borrower",
+        "type": "address"
+      },
+      {
+        "internalType": "uint256",
+        "name": "seizeTokens",
+        "type": "uint256"
+      }
+    ],
+    "name": "seize",
+    "outputs": [
+      {
+        "internalType": "uint256",
+        "name": "",
+        "type": "uint256"
+      }
+    ],
+    "stateMutability": "nonpayable",
+    "type": "function"
+  },
+  {
+    "inputs": [],
+    "name": "supplyRatePerBlock",
+    "outputs": [
+      {
+        "internalType": "uint256",
+        "name": "",
+        "type": "uint256"
+      }
+    ],
+    "stateMutability": "view",
     "type": "function"
   },
   {
@@ -696,7 +1387,59 @@
   },
   {
     "inputs": [],
-    "name": "totalAssets",
+    "name": "totalAdminFees",
+    "outputs": [
+      {
+        "internalType": "uint256",
+        "name": "",
+        "type": "uint256"
+      }
+    ],
+    "stateMutability": "view",
+    "type": "function"
+  },
+  {
+    "inputs": [],
+    "name": "totalBorrows",
+    "outputs": [
+      {
+        "internalType": "uint256",
+        "name": "",
+        "type": "uint256"
+      }
+    ],
+    "stateMutability": "view",
+    "type": "function"
+  },
+  {
+    "inputs": [],
+    "name": "totalBorrowsCurrent",
+    "outputs": [
+      {
+        "internalType": "uint256",
+        "name": "",
+        "type": "uint256"
+      }
+    ],
+    "stateMutability": "nonpayable",
+    "type": "function"
+  },
+  {
+    "inputs": [],
+    "name": "totalFuseFees",
+    "outputs": [
+      {
+        "internalType": "uint256",
+        "name": "",
+        "type": "uint256"
+      }
+    ],
+    "stateMutability": "view",
+    "type": "function"
+  },
+  {
+    "inputs": [],
+    "name": "totalReserves",
     "outputs": [
       {
         "internalType": "uint256",
@@ -724,7 +1467,7 @@
     "inputs": [
       {
         "internalType": "address",
-        "name": "to",
+        "name": "dst",
         "type": "address"
       },
       {
@@ -748,12 +1491,12 @@
     "inputs": [
       {
         "internalType": "address",
-        "name": "from",
+        "name": "src",
         "type": "address"
       },
       {
         "internalType": "address",
-        "name": "to",
+        "name": "dst",
         "type": "address"
       },
       {
@@ -774,32 +1517,16 @@
     "type": "function"
   },
   {
-    "inputs": [
-      {
-        "internalType": "uint256",
-        "name": "assets",
-        "type": "uint256"
-      },
-      {
-        "internalType": "address",
-        "name": "receiver",
-        "type": "address"
-      },
-      {
-        "internalType": "address",
-        "name": "owner",
-        "type": "address"
-      }
-    ],
-    "name": "withdraw",
+    "inputs": [],
+    "name": "underlying",
     "outputs": [
       {
-        "internalType": "uint256",
-        "name": "shares",
-        "type": "uint256"
+        "internalType": "address",
+        "name": "",
+        "type": "address"
       }
     ],
-    "stateMutability": "nonpayable",
+    "stateMutability": "view",
     "type": "function"
   }
 ]

--- a/packages/functions/src/controllers/flywheel.ts
+++ b/packages/functions/src/controllers/flywheel.ts
@@ -4,49 +4,64 @@ import CTOKEN_ABI from '../abi/ctoken.json';
 import { flywheels } from '../assets';
 import { config, supabase, SupportedChains } from '../config';
 
-const updateFlyWheelData = async (chainId: SupportedChains, rpcUrl: string) => {
+const updateFlywheelData = async (chainId: SupportedChains, rpcUrl: string) => {
   try {
     const provider = new ethers.providers.StaticJsonRpcProvider(rpcUrl);
     const supportedFlywheels = flywheels[chainId];
 
     for (const flywheel of supportedFlywheels) {
       const flywheelContract = new ethers.Contract(flywheel, FLYWHEEL_ABI, provider);
+      // Naming is misleading, strategies => enabled markets
       const strategies = await flywheelContract.getAllStrategies();
       for (const strategy of strategies) {
         try {
           const pluginContract = new ethers.Contract(strategy, CTOKEN_ABI, provider);
-          const state = await flywheelContract.strategyState(strategy);
-          const flywheelAsset = await flywheelContract.rewardToken();
-          const totalSupply = await pluginContract.totalSupply();
-          const underlyingAsset = await pluginContract.underlying();
+
+          const [state, rewardToken, totalSupply, underlyingAsset, pluginAddress] =
+            await Promise.all([
+              flywheelContract.callStatic.strategyState(strategy),
+              flywheelContract.callStatic.rewardToken(),
+              pluginContract.callStatic.totalSupply(),
+              pluginContract.callStatic.underlying(),
+              pluginContract.callStatic.plugin(),
+            ]);
+          console.log({
+            state,
+            rewardToken,
+            totalSupply,
+            underlyingAsset,
+            pluginAddress,
+          });
+
           const index = state['index'];
           const pricePerShare = !totalSupply.eq('0') ? index / totalSupply : 0;
+
           const { error } = await supabase.from(config.supabaseFlywheelTableName).insert([
             {
               totalAssets: index.toString(),
               totalSupply: totalSupply.toString(),
               pricePerShare: pricePerShare.toString(),
-              rewardAddress: flywheelAsset.toLowerCase(),
-              pluginAddress: strategy.toLowerCase(),
+              rewardAddress: rewardToken.toLowerCase(),
+              pluginAddress: pluginAddress.toLowerCase(),
               underlyingAddress: underlyingAsset.toLowerCase(),
               chain: chainId,
             },
           ]);
           if (error) {
-            console.log(
-              `Error occurred during savin data for flywheel's plugin ${strategy}: ${error.message}`
+            console.error(
+              `Error occurred during saving data for flywheel's plugin ${strategy}: ${error.message}`
             );
           } else {
             console.log(`Successfully saved data for flywheel's plugin ${strategy}`);
           }
         } catch (err) {
-          console.log(err);
+          console.error(err);
         }
       }
     }
   } catch (err) {
-    console.log(err);
+    console.error(err);
   }
 };
 
-export default updateFlyWheelData;
+export default updateFlywheelData;

--- a/packages/functions/src/controllers/flywheel.ts
+++ b/packages/functions/src/controllers/flywheel.ts
@@ -25,13 +25,13 @@ const updateFlywheelData = async (chainId: SupportedChains, rpcUrl: string) => {
               pluginContract.callStatic.underlying(),
               pluginContract.callStatic.plugin(),
             ]);
-          console.log({
-            state,
-            rewardToken,
-            totalSupply,
-            underlyingAsset,
-            pluginAddress,
-          });
+          // console.log({
+          //   state,
+          //   rewardToken,
+          //   totalSupply,
+          //   underlyingAsset,
+          //   pluginAddress,
+          // });
 
           const index = state['index'];
           const pricePerShare = !totalSupply.eq('0') ? index / totalSupply : 0;
@@ -48,9 +48,7 @@ const updateFlywheelData = async (chainId: SupportedChains, rpcUrl: string) => {
             },
           ]);
           if (error) {
-            console.error(
-              `Error occurred during saving data for flywheel's plugin ${strategy}: ${error.message}`
-            );
+            throw `Error occurred during saving data for flywheel's plugin ${pluginAddress}: ${error.message}`;
           } else {
             console.log(`Successfully saved data for flywheel's plugin ${strategy}`);
           }

--- a/packages/functions/src/controllers/index.ts
+++ b/packages/functions/src/controllers/index.ts
@@ -1,2 +1,2 @@
-export { default as updateFlyWheelData } from './flywheel';
+export { default as updateFlywheelData } from './flywheel';
 export { default as updatePluginsData } from './plugins';

--- a/packages/functions/src/controllers/plugins.ts
+++ b/packages/functions/src/controllers/plugins.ts
@@ -17,7 +17,7 @@ const updatePluginsData = async (chainId: SupportedChains, rpcUrl: string) => {
           contract.callStatic.totalAssets(),
           contract.callStatic.asset(),
         ]);
-        console.log({ totalSupply, totalAssets, underlyingAsset });
+        // console.log({ totalSupply, totalAssets, underlyingAsset });
 
         const pricePerShare = !totalSupply.eq('0') ? totalAssets / totalSupply : 0;
 
@@ -32,9 +32,7 @@ const updatePluginsData = async (chainId: SupportedChains, rpcUrl: string) => {
           },
         ]);
         if (error) {
-          console.error(
-            `Error occurred during saving data for plugin ${plugin}:  ${error.message}`
-          );
+          throw `Error occurred during saving data for plugin ${plugin}:  ${error.message}`;
         } else {
           console.log(`Successfully saved data for plugin ${plugin}`);
         }

--- a/packages/functions/src/controllers/plugins.ts
+++ b/packages/functions/src/controllers/plugins.ts
@@ -11,10 +11,14 @@ const updatePluginsData = async (chainId: SupportedChains, rpcUrl: string) => {
     for (const plugin of supportedPlugins) {
       try {
         const contract = new ethers.Contract(plugin, PLUGINS_ABI, provider);
-        const totalSupply = await contract.totalSupply();
-        const totalAssets = await contract.totalAssets();
-        const underlyingAsset = await contract.asset();
-        console.log(totalSupply);
+
+        const [totalSupply, totalAssets, underlyingAsset] = await Promise.all([
+          contract.callStatic.totalSupply(),
+          contract.callStatic.totalAssets(),
+          contract.callStatic.asset(),
+        ]);
+        console.log({ totalSupply, totalAssets, underlyingAsset });
+
         const pricePerShare = !totalSupply.eq('0') ? totalAssets / totalSupply : 0;
 
         const { error } = await supabase.from(config.supabasePluginTableName).insert([
@@ -28,16 +32,18 @@ const updatePluginsData = async (chainId: SupportedChains, rpcUrl: string) => {
           },
         ]);
         if (error) {
-          console.log(`Error occurred during saving data for plugin ${plugin}:  ${error.message}`);
+          console.error(
+            `Error occurred during saving data for plugin ${plugin}:  ${error.message}`
+          );
         } else {
           console.log(`Successfully saved data for plugin ${plugin}`);
         }
       } catch (err) {
-        console.log(err);
+        throw err;
       }
     }
   } catch (err) {
-    console.log(err);
+    console.error(err);
   }
 };
 

--- a/packages/functions/src/functions/bsc-save-price.ts
+++ b/packages/functions/src/functions/bsc-save-price.ts
@@ -1,11 +1,11 @@
 import { Handler } from '@netlify/functions';
 import { rpcUrls } from '../assets';
 import { SupportedChains } from '../config';
-import { updateFlyWheelData, updatePluginsData } from '../controllers';
+import { updateFlywheelData, updatePluginsData } from '../controllers';
 
 const handler: Handler = async (event, context) => {
   await updatePluginsData(SupportedChains.bsc, rpcUrls[SupportedChains.bsc]);
-  await updateFlyWheelData(SupportedChains.bsc, rpcUrls[SupportedChains.bsc]);
+  await updateFlywheelData(SupportedChains.bsc, rpcUrls[SupportedChains.bsc]);
 
   return {
     statusCode: 200,

--- a/packages/functions/src/functions/moonbeam-save-price.ts
+++ b/packages/functions/src/functions/moonbeam-save-price.ts
@@ -1,11 +1,11 @@
 import { Handler } from '@netlify/functions';
 import { rpcUrls } from '../assets';
 import { SupportedChains } from '../config';
-import { updateFlyWheelData, updatePluginsData } from '../controllers';
+import { updateFlywheelData, updatePluginsData } from '../controllers';
 
 const handler: Handler = async (event, context) => {
   await updatePluginsData(SupportedChains.moonbeam, rpcUrls[SupportedChains.moonbeam]);
-  await updateFlyWheelData(SupportedChains.moonbeam, rpcUrls[SupportedChains.moonbeam]);
+  await updateFlywheelData(SupportedChains.moonbeam, rpcUrls[SupportedChains.moonbeam]);
 
   return {
     statusCode: 200,

--- a/packages/sdk/src/chainConfig/plugins.ts
+++ b/packages/sdk/src/chainConfig/plugins.ts
@@ -9,7 +9,7 @@ const chainDeployedPlugins: ChainDeployedPlugins = {
       market: "0x34ea4cbb464E6D120B081661464d4635Ca237FA7",
       name: "Bomb",
     },
-    "0x6b8b935dfc9dcd0754eced708b1b633bf73fe854": {
+    "0x6B8B935dfC9Dcd0754eced708b1b633BF73FE854": {
       market: "0x4cF3D3ca995beEeEd83f67A5C0456A13e038f7b8",
       name: "BTCB-BOMB",
     },

--- a/packages/sdk/tasks/jarvisFix.ts
+++ b/packages/sdk/tasks/jarvisFix.ts
@@ -48,7 +48,7 @@ task("jarvis-fix", "deploy new strategy for jarvis 2brl pool")
     });
     console.log(`Plugin deployed successfully: ${pluginDeployment.address}`);
 
-    // // Step 2: update plugin, use same implementation
+    // // Step 2: update market, use same implementation
     // const currentImplementation = await cToken.callStatic.implementation();
     // console.log({ currentImplementation });
     // const abiCoder = new hre.ethers.utils.AbiCoder();
@@ -61,7 +61,7 @@ task("jarvis-fix", "deploy new strategy for jarvis 2brl pool")
     // const upgradeResult = await upgradeTx.wait(2);
     // console.log("changed plugin successfully");
 
-    // Step 3: Approve fwc Rewards to get rewardTokens from it
+    // Step 3: Approve fwc Rewards to get rewardTokens from it (!IMPORTANT to use "approve(address,address)", it has two approve functions)
     const dddRewards = await dddFlywheel.callStatic.flywheelRewards();
     console.log({ dddRewards });
     const approveDDDTx = await cToken["approve(address,address)"](dddAddress, dddRewards);

--- a/packages/sdk/tests/unit/FlywheelModule.spec.ts
+++ b/packages/sdk/tests/unit/FlywheelModule.spec.ts
@@ -30,8 +30,8 @@ describe("FlywheelModule", function () {
 
     sdk = await getOrCreateFuse();
 
-    [poolAAddress] = await poolHelpers.createPool({ signer: deployer, poolName: "PoolA-FlyWheel-Test" });
-    [poolBAddress] = await poolHelpers.createPool({ signer: deployer, poolName: "PoolB-FlyWheel-Test" });
+    [poolAAddress] = await poolHelpers.createPool({ signer: deployer, poolName: "PoolA-Flywheel-Test" });
+    [poolBAddress] = await poolHelpers.createPool({ signer: deployer, poolName: "PoolB-Flywheel-Test" });
 
     const assetsA = await assetHelpers.getAssetsConf(
       poolAAddress,

--- a/packages/ui/hooks/useApy.ts
+++ b/packages/ui/hooks/useApy.ts
@@ -7,7 +7,7 @@ export function useApy(underlyingAddress: string, pluginAddress: string, rewardA
     currentChain: { id: currentChainId },
   } = useRari();
   return useQuery(
-    ['useApy', underlyingAddress, pluginAddress, rewardAddress],
+    ['useApy', currentChainId, underlyingAddress, pluginAddress, rewardAddress],
     async () => {
       return await fetch(
         `/api/apyData?chain=${currentChainId}&underlyingAddress=${underlyingAddress}&pluginAddress=${pluginAddress}${


### PR DESCRIPTION
## Description

save prices function had a minor flaw, that is was assuming the "strategy" is the plugin. However, the strategy of a flywheel is actually the market address. Thereby the flywheel strategies of ddd and epx for 2brl in the jarvis pool had no entries. As it was looking up with the plugin address but it saved the market address in the table.

https://github.com/Midas-Protocol/monorepo/blob/eb2cf794f0f93d319c110f5e008bc0b31879ff3b/packages/functions/src/controllers/flywheel.ts#L26