### PR TITLE
Reduce Lint Warnings

### DIFF
--- a/packages/sdk/chainDeploy/local/local.ts
+++ b/packages/sdk/chainDeploy/local/local.ts
@@ -1,6 +1,7 @@
+/* eslint-disable no-console, @typescript-eslint/no-non-null-assertion */
+
 import { ethers } from "ethers";
 
-import { AddressesProvider } from "../../lib/contracts/typechain/AddressesProvider";
 import { FixedNativePriceOracle } from "../../lib/contracts/typechain/FixedNativePriceOracle";
 import { MasterPriceOracle } from "../../lib/contracts/typechain/MasterPriceOracle";
 import { SupportedChains } from "../../src";

--- a/packages/sdk/chainDeploy/mainnets/bsc.ts
+++ b/packages/sdk/chainDeploy/mainnets/bsc.ts
@@ -1,3 +1,5 @@
+/* eslint-disable no-console, @typescript-eslint/no-non-null-assertion */
+
 import { ethers, utils } from "ethers";
 
 import { AddressesProvider } from "../../lib/contracts/typechain/AddressesProvider";

--- a/packages/sdk/chainDeploy/mainnets/evmos.ts
+++ b/packages/sdk/chainDeploy/mainnets/evmos.ts
@@ -1,3 +1,5 @@
+/* eslint-disable no-console, @typescript-eslint/no-non-null-assertion */
+
 import { SupportedChains } from "../../src";
 import { assetSymbols, chainSpecificParams, chainSupportedAssets } from "../../src/chainConfig";
 import { SupportedAsset } from "../../src/types";

--- a/packages/sdk/chainDeploy/mainnets/moonbeam.ts
+++ b/packages/sdk/chainDeploy/mainnets/moonbeam.ts
@@ -1,3 +1,5 @@
+/* eslint-disable no-console, @typescript-eslint/no-non-null-assertion */
+
 import { ethers } from "ethers";
 
 import { SupportedChains } from "../../src";

--- a/packages/sdk/chainDeploy/mainnets/polygon.ts
+++ b/packages/sdk/chainDeploy/mainnets/polygon.ts
@@ -1,3 +1,5 @@
+/* eslint-disable no-console, @typescript-eslint/no-non-null-assertion */
+
 import { ethers } from "ethers";
 
 import { AddressesProvider } from "../../lib/contracts/typechain/AddressesProvider";

--- a/packages/sdk/chainDeploy/testnets/chapel.ts
+++ b/packages/sdk/chainDeploy/testnets/chapel.ts
@@ -1,4 +1,6 @@
-import { ethers, utils } from "ethers";
+/* eslint-disable no-console, @typescript-eslint/no-non-null-assertion */
+
+import { ethers } from "ethers";
 
 import { SupportedChains } from "../../src";
 import { assetSymbols, chainSpecificParams, chainSupportedAssets } from "../../src/chainConfig";

--- a/packages/sdk/chainDeploy/testnets/evmostestnet.ts
+++ b/packages/sdk/chainDeploy/testnets/evmostestnet.ts
@@ -1,3 +1,5 @@
+/* eslint-disable no-console, @typescript-eslint/no-non-null-assertion */
+
 import { constants, ethers, providers, utils } from "ethers";
 
 import { SupportedChains } from "../../src";

--- a/packages/sdk/chainDeploy/testnets/kovan.ts
+++ b/packages/sdk/chainDeploy/testnets/kovan.ts
@@ -1,4 +1,4 @@
-import { utils } from "ethers";
+/* eslint-disable no-console, @typescript-eslint/no-non-null-assertion */
 
 import { SupportedChains } from "../../src";
 import { chainSpecificParams } from "../../src/chainConfig";

--- a/packages/sdk/chainDeploy/testnets/moonbase.ts
+++ b/packages/sdk/chainDeploy/testnets/moonbase.ts
@@ -1,4 +1,6 @@
-import { ethers, providers, utils } from "ethers";
+/* eslint-disable no-console, @typescript-eslint/no-non-null-assertion */
+
+import { ethers, providers } from "ethers";
 
 import { SupportedChains } from "../../src";
 import { assetSymbols, chainSpecificParams, chainSupportedAssets } from "../../src/chainConfig";

--- a/packages/sdk/chainDeploy/testnets/neondevnet.ts
+++ b/packages/sdk/chainDeploy/testnets/neondevnet.ts
@@ -1,3 +1,5 @@
+/* eslint-disable no-console, @typescript-eslint/no-non-null-assertion */
+
 import { ethers, utils } from "ethers";
 
 import { SupportedChains } from "../../src";


### PR DESCRIPTION
organizes imports and allows console.log and null assertions in deploy scripts to reduce linter warnings in CI and IDE
