### PR TITLE
Consider Underlyings Decimals before Applying Native Prices

### DIFF
--- a/packages/sdk/src/modules/FusePools.ts
+++ b/packages/sdk/src/modules/FusePools.ts
@@ -87,33 +87,38 @@ export function withFusePools<TBase extends MidasBaseConstructor>(Base: TBase) {
         );
 
         asset.supplyBalanceNative =
-          Number(utils.formatUnits(asset.supplyBalance)) * Number(utils.formatUnits(asset.underlyingPrice));
+          Number(utils.formatUnits(asset.supplyBalance, asset.underlyingDecimals)) *
+          Number(utils.formatUnits(asset.underlyingPrice));
 
         asset.borrowBalanceNative =
-          Number(utils.formatUnits(asset.borrowBalance)) * Number(utils.formatUnits(asset.underlyingPrice));
+          Number(utils.formatUnits(asset.borrowBalance, asset.underlyingDecimals)) *
+          Number(utils.formatUnits(asset.underlyingPrice));
 
         totalSupplyBalanceNative += asset.supplyBalanceNative;
         totalBorrowBalanceNative += asset.borrowBalanceNative;
 
         asset.totalSupplyNative =
-          Number(utils.formatUnits(asset.totalSupply)) * Number(utils.formatUnits(asset.underlyingPrice));
+          Number(utils.formatUnits(asset.totalSupply, asset.underlyingDecimals)) *
+          Number(utils.formatUnits(asset.underlyingPrice));
         asset.totalBorrowNative =
-          Number(utils.formatUnits(asset.totalBorrow)) * Number(utils.formatUnits(asset.underlyingPrice));
+          Number(utils.formatUnits(asset.totalBorrow, asset.underlyingDecimals)) *
+          Number(utils.formatUnits(asset.underlyingPrice));
 
         if (asset.totalSupplyNative === 0) {
           asset.utilization = 0;
         } else {
           asset.utilization = (asset.totalBorrowNative / asset.totalSupplyNative) * 100;
         }
-        const assetLiquidity =
-          Number(utils.formatUnits(asset.liquidity)) * Number(utils.formatUnits(asset.underlyingPrice));
 
         totalSuppliedNative += asset.totalSupplyNative;
         totalBorrowedNative += asset.totalBorrowNative;
 
-        asset.liquidityNative = assetLiquidity;
+        const assetLiquidityNative =
+          Number(utils.formatUnits(asset.liquidity, asset.underlyingDecimals)) *
+          Number(utils.formatUnits(asset.underlyingPrice));
+        asset.liquidityNative = assetLiquidityNative;
 
-        totalAvailableLiquidityNative += asset.isBorrowPaused ? 0 : assetLiquidity;
+        totalAvailableLiquidityNative += asset.isBorrowPaused ? 0 : assetLiquidityNative;
         totalLiquidityNative += asset.liquidityNative;
 
         if (!asset.isBorrowPaused) {


### PR DESCRIPTION
convert to numbers considering the assets decimals before multiplying the price.


<img width="741" alt="Screenshot 2022-09-02 at 12 23 15" src="https://user-images.githubusercontent.com/839848/188120183-30587d27-9af0-4e68-a9f0-6538284af59d.png">
