### PR TITLE
minBorrow native scaled 1e18

### DIFF
--- a/packages/ui/hooks/useBorrowLimit.ts
+++ b/packages/ui/hooks/useBorrowLimit.ts
@@ -84,7 +84,7 @@ export const useAssetMinBorrow = (underlyingDecimals: BigNumber, underlyingPrice
     [`useMinBorrow`, minBorrowNative, underlyingDecimals, underlyingPrice],
     () => {
       if (minBorrowNative) {
-        return minBorrowNative.mul(utils.parseUnits('1', underlyingDecimals)).div(underlyingPrice);
+        return minBorrowNative.mul(utils.parseUnits('1', DEFAULT_DECIMALS)).div(underlyingPrice);
       }
     },
     {


### PR DESCRIPTION
returned value of `FuseFeeDistributor.callStatic.minBorrowEth()` seems to be scaled `1e18` not ` underlyingDecimals`