### PR TITLE
added vault details in plugin tooltip & pointed strategy address

### DIFF
--- a/packages/ui/components/pages/Fuse/FusePoolPage/SupplyList/AssetSupplyRow.tsx
+++ b/packages/ui/components/pages/Fuse/FusePoolPage/SupplyList/AssetSupplyRow.tsx
@@ -227,35 +227,34 @@ export const AssetSupplyRow = ({
                   placement="top-start"
                   body={
                     <Text lineHeight="base">
-                      This market is using the <b>{pluginInfo?.name}</b> ERC4626 Strategy(
-                      <b>{asset.plugin}</b>).
+                      This market is using the <b>{pluginInfo?.name}</b> ERC4626 Strategy.
                       <br />
-                      {pluginInfo?.apyDocsUrl && (
+                      {pluginInfo?.apyDocsUrl ? (
+                        <ChakraLink
+                          href={pluginInfo.apyDocsUrl}
+                          isExternal
+                          variant={'color'}
+                          onClick={(e) => {
+                            e.stopPropagation();
+                          }}
+                        >
+                          Vault details
+                        </ChakraLink>
+                      ) : (
                         <>
+                          Read more about it{' '}
                           <ChakraLink
-                            href={pluginInfo.apyDocsUrl}
+                            href={pluginInfo?.strategyDocsUrl || URL_MIDAS_DOCS}
                             isExternal
                             variant={'color'}
                             onClick={(e) => {
                               e.stopPropagation();
                             }}
                           >
-                            [Vault details]
+                            in our Docs <ExternalLinkIcon mx="2px" />
                           </ChakraLink>
-                          <br />
                         </>
                       )}
-                      Read more about it{' '}
-                      <ChakraLink
-                        href={pluginInfo?.strategyDocsUrl || URL_MIDAS_DOCS}
-                        isExternal
-                        variant={'color'}
-                        onClick={(e) => {
-                          e.stopPropagation();
-                        }}
-                      >
-                        in our Docs <ExternalLinkIcon mx="2px" />
-                      </ChakraLink>
                       .
                     </Text>
                   }

--- a/packages/ui/components/pages/Fuse/FusePoolPage/SupplyList/AssetSupplyRow.tsx
+++ b/packages/ui/components/pages/Fuse/FusePoolPage/SupplyList/AssetSupplyRow.tsx
@@ -226,9 +226,25 @@ export const AssetSupplyRow = ({
                 <PopoverTooltip
                   placement="top-start"
                   body={
-                    <>
-                      This market is using the <b>{pluginInfo?.name}</b> ERC4626 Strategy.
+                    <Text lineHeight="base">
+                      This market is using the <b>{pluginInfo?.name}</b> ERC4626 Strategy(
+                      <b>{asset.plugin}</b>).
                       <br />
+                      {pluginInfo?.apyDocsUrl && (
+                        <>
+                          <ChakraLink
+                            href={pluginInfo.apyDocsUrl}
+                            isExternal
+                            variant={'color'}
+                            onClick={(e) => {
+                              e.stopPropagation();
+                            }}
+                          >
+                            [Vault details]
+                          </ChakraLink>
+                          <br />
+                        </>
+                      )}
                       Read more about it{' '}
                       <ChakraLink
                         href={pluginInfo?.strategyDocsUrl || URL_MIDAS_DOCS}
@@ -241,7 +257,7 @@ export const AssetSupplyRow = ({
                         in our Docs <ExternalLinkIcon mx="2px" />
                       </ChakraLink>
                       .
-                    </>
+                    </Text>
                   }
                 >
                   <span role="img" aria-label="plugin" style={{ fontSize: 18 }}>


### PR DESCRIPTION
`Vault details` added
![image](https://user-images.githubusercontent.com/45715420/189004021-af589a7d-b888-4c93-b86f-13e47b04d31c.png)



I am not sure the methods to point strategy address
Option1) Showing address beside of strategy name in the tooltip like below
![image](https://user-images.githubusercontent.com/45715420/189004619-8f42103e-1154-49ee-b89c-8d7209b36f8f.png)

Option2) Link to BSC scan with strategy address when clicking strategy name in the tooltip
![image](https://user-images.githubusercontent.com/45715420/189005518-1ba47ba9-1e64-49db-b265-f132304c0d74.png)

Which way should I go? cc @carlomazzaferro  @peetzweg 