### PR TITLE
Deploy PR as `preview.midascapital.xyz` if labeled with `preview`

### DIFF
--- a/.github/workflows/package-ui-deploy-preview.yaml
+++ b/.github/workflows/package-ui-deploy-preview.yaml
@@ -1,0 +1,49 @@
+name: UI - deploy UI
+
+on:
+  pull_request:
+    branches: [main, development]
+    types: [ labeled ]
+    paths:
+      - 'packages/ui/**'
+      - 'packages/sdk/**'
+      - 'packages/chains/**'
+      - 'packages/types/**'
+      - 'packages/functions/**'
+      - '.github/workflows/package-ui-deploy.yaml'
+      - 'yarn.lock'
+      - 'netlify.toml'
+
+jobs:
+  deploy-preview:
+    if: ${{ github.event.label.name == 'preview' }}
+    runs-on: ubuntu-latest
+    env:
+      NETLIFY_AUTH_TOKEN: ${{ secrets.NETLIFY_AUTH_TOKEN }}
+    steps:
+      - uses: actions/checkout@v3
+        with:
+          submodules: recursive
+          token: '${{ secrets.ACCESS_TOKEN }}'
+
+      - uses: actions/setup-node@v3
+        with:
+          node-version: '16'
+          cache: 'yarn'
+
+      - name: Install `foundry`
+        uses: onbjerg/foundry-toolchain@v1
+        with:
+          version: nightly
+
+      - name: Install `packages`
+        run: yarn install
+        env:
+          # Fixes issue: `ethereumjs-abi: The remote archive doesn't match the expected checksum`
+          YARN_CHECKSUM_BEHAVIOR: update
+
+      - name: Deploy `Preview`
+        run: |
+          netlify link --id ${{ secrets.NETLIFY_SITE_ID_PREVIEW }}
+          netlify deploy --prod --build --context branch-deploy
+

--- a/.github/workflows/package-ui-deploy-preview.yaml
+++ b/.github/workflows/package-ui-deploy-preview.yaml
@@ -3,7 +3,7 @@ name: UI - deploy UI
 on:
   pull_request:
     branches: [main, development]
-    types: [ labeled ]
+    types: [labeled, opened,synchronize,reopened]
     paths:
       - 'packages/ui/**'
       - 'packages/sdk/**'
@@ -16,7 +16,7 @@ on:
 
 jobs:
   deploy-preview:
-    if: ${{ github.event.label.name == 'preview' }}
+    if: contains(github.event.pull_request.labels.*.name, 'preview')
     runs-on: ubuntu-latest
     env:
       NETLIFY_AUTH_TOKEN: ${{ secrets.NETLIFY_AUTH_TOKEN }}

--- a/.github/workflows/package-ui-deploy.yaml
+++ b/.github/workflows/package-ui-deploy.yaml
@@ -2,7 +2,7 @@ name: UI - deploy UI
 
 on:
   push:
-    branches: [main, development, preview]
+    branches: [main, development]
     paths:
       - 'packages/ui/**'
       - 'packages/sdk/**'
@@ -39,13 +39,6 @@ jobs:
         env:
           # Fixes issue: `ethereumjs-abi: The remote archive doesn't match the expected checksum`
           YARN_CHECKSUM_BEHAVIOR: update
-
-      - name: Deploy `Preview`
-        if: github.ref == 'refs/heads/preview'
-        run: |
-          netlify link --id ${{ secrets.NETLIFY_SITE_ID_PREVIEW }}
-          netlify deploy --prod --build --context branch-deploy
-
 
       - name: Deploy `Development`
         if: github.ref == 'refs/heads/development'

--- a/package.json
+++ b/package.json
@@ -46,8 +46,8 @@
     "dev:node": "yarn workspace @midas-capital/sdk hardhat node --no-deploy",
     "dev:node:deploy": "yarn workspace @midas-capital/sdk deploy:localhost",
     "dev:node:fork": "yarn workspace @midas-capital/sdk hardhat node --port 8545 --no-deploy",
-    "dev:node:bsc":"FORK_CHAIN_ID=56 FORK_RPC_URL=$BSC_RPC_URL yarn workspace @midas-capital/sdk hardhat node --port 8545 --no-deploy",
-    "dev:node:polygon":"FORK_CHAIN_ID=137 FORK_RPC_URL=$POLYGON_RPC_URL yarn workspace @midas-capital/sdk hardhat node --port 8546 --no-deploy",
+    "dev:node:bsc": "FORK_CHAIN_ID=56 FORK_RPC_URL=$BSC_RPC_URL yarn workspace @midas-capital/sdk hardhat node --port 8545 --no-deploy",
+    "dev:node:polygon": "FORK_CHAIN_ID=137 FORK_RPC_URL=$POLYGON_RPC_URL yarn workspace @midas-capital/sdk hardhat node --port 8546 --no-deploy",
     "dev:simulate:deploy:bsc": "FORK_RPC_URL=${FORK_RPC_URL} FORK_BLOCK_NUMBER= FORK_CHAIN_ID=56 yarn workspace @midas-capital/sdk hardhat node --tags prod",
     "test:ui": "yarn workspace @midas-capital/ui test"
   }

--- a/packages/ui/components/pages/Fuse/FusePoolsPage/FuseStatsBar/index.tsx
+++ b/packages/ui/components/pages/Fuse/FusePoolsPage/FuseStatsBar/index.tsx
@@ -66,7 +66,7 @@ const FuseStatsBar = () => {
         marginRight={{ base: '0px', lg: '84.5px' }}
       >
         <Text variant="heading" fontWeight="bold">
-          PREVIEW deployed
+          Unleash the power of your assets
         </Text>
         <Text variant="mdText" my={4} zIndex="100" lineHeight={8}>
           Let your holdings shine with the Midas Touch. From an individual DeFi user to a DAO or

--- a/packages/ui/components/pages/Fuse/FusePoolsPage/FuseStatsBar/index.tsx
+++ b/packages/ui/components/pages/Fuse/FusePoolsPage/FuseStatsBar/index.tsx
@@ -66,7 +66,7 @@ const FuseStatsBar = () => {
         marginRight={{ base: '0px', lg: '84.5px' }}
       >
         <Text variant="heading" fontWeight="bold">
-          Unleash the power of your assets
+          PREVIEW deployed
         </Text>
         <Text variant="mdText" my={4} zIndex="100" lineHeight={8}>
           Let your holdings shine with the Midas Touch. From an individual DeFi user to a DAO or


### PR DESCRIPTION
If a PR to `main` or `development` is labeled with `preview` it will be deployed to `preview.midascapital.xyz`. So we can individually decide now for which PRs we need a live available preview for everyone.

So the deployment to `preview.midascapital.xyz` is not tied to the previously existing `preview` branch.

<img width="1636" alt="Screenshot 2022-10-06 at 15 31 24" src="https://user-images.githubusercontent.com/839848/194326518-0ac51b42-8510-4e92-8fc8-18c727991070.png">

<img width="1282" alt="Screenshot 2022-10-06 at 15 31 18" src="https://user-images.githubusercontent.com/839848/194326531-b7168c63-1e92-4347-a9ba-3b62019e6b1b.png">

<img width="874" alt="Screenshot 2022-10-06 at 15 40 29" src="https://user-images.githubusercontent.com/839848/194328456-0ae29b7a-048e-49a8-b6dd-cecbbb9ccc09.png">


