### PR TITLE
Adds `jEUR`

### DIFF
--- a/packages/chains/src/bsc/assets.ts
+++ b/packages/chains/src/bsc/assets.ts
@@ -29,6 +29,7 @@ const stkBNB_WBNB = "0xaA2527ff1893e0D40d4a454623d362B79E8bb7F1";
 const stkBNB = "0xc2E9d07F66A89c44062459A47a0D2Dc038E4fb16";
 const jBRL = "0x316622977073BBC3dF32E7d2A9B3c77596a0a603";
 const jCHF = "0x7c869b5A294b1314E985283d01C702B62224a05f";
+const jEUR = "0x23b8683Ff98F9E4781552DFE6f12Aa32814924e8";
 const BRZ = "0x71be881e9C5d4465B3FfF61e89c6f3651E69B5bb";
 const BRZw = "0x5b1a9850f55d9282a7C4Bf23A2a21B050e3Beb2f";
 const BTCB_BOMB = "0x84392649eb0bC1c1532F2180E58Bae4E1dAbd8D6";
@@ -273,6 +274,14 @@ const assets: SupportedAsset[] = [
     symbol: assetSymbols.JCHF,
     underlying: jCHF,
     name: "Jarvis Synthetic Swiss Franc",
+    decimals: 18,
+    oracle: OracleTypes.ChainlinkPriceOracleV2,
+    extraDocs: jarvisDocs("v1"),
+  },
+  {
+    symbol: assetSymbols.JEUR,
+    underlying: jEUR,
+    name: "Jarvis Synthetic Euro",
     decimals: 18,
     oracle: OracleTypes.ChainlinkPriceOracleV2,
     extraDocs: jarvisDocs("v1"),

--- a/packages/sdk/chainDeploy/mainnets/bsc.ts
+++ b/packages/sdk/chainDeploy/mainnets/bsc.ts
@@ -181,6 +181,11 @@ const chainlinkAssets: ChainlinkAsset[] = [
     feedBaseCurrency: ChainlinkFeedBaseCurrency.USD,
   },
   {
+    symbol: assetSymbols.JEUR,
+    aggregator: "0x0bf79F617988C472DcA68ff41eFe1338955b9A80",
+    feedBaseCurrency: ChainlinkFeedBaseCurrency.USD,
+  },
+  {
     symbol: assetSymbols.BRZ,
     aggregator: "0x5cb1Cb3eA5FB46de1CE1D0F3BaDB3212e8d8eF48",
     feedBaseCurrency: ChainlinkFeedBaseCurrency.USD,


### PR DESCRIPTION
jEUR: `0x0bf79F617988C472DcA68ff41eFe1338955b9A80`
https://bscscan.com/address/0x0bf79F617988C472DcA68ff41eFe1338955b9A80

https://docs.chain.link/docs/data-feeds/price-feeds/addresses/?network=bnb-chain

<img width="897" alt="Screenshot 2022-10-19 at 17 09 27" src="https://user-images.githubusercontent.com/839848/196730766-795b6ce9-dc78-4cb3-9d82-6c23f4d433ca.png">
