### PR TITLE
refactor chainIdToConfig

### DIFF
--- a/packages/bots/liquidator/src/utils/setUpSdk.ts
+++ b/packages/bots/liquidator/src/utils/setUpSdk.ts
@@ -1,20 +1,8 @@
 import { JsonRpcProvider } from "@ethersproject/providers";
-import { bsc, chapel, evmos, fantom, ganache, moonbeam, neondevnet, polygon } from "@midas-capital/chains";
+import { chainIdToConfig } from "@midas-capital/chains";
 import { MidasSdk } from "@midas-capital/sdk";
-import { ChainConfig } from "@midas-capital/types";
 
 import { logger } from "..";
-
-const chainIdToConfig: { [chainId: number]: ChainConfig } = {
-  [bsc.chainId]: bsc,
-  [polygon.chainId]: polygon,
-  [moonbeam.chainId]: moonbeam,
-  [evmos.chainId]: evmos,
-  [fantom.chainId]: fantom,
-  [neondevnet.chainId]: neondevnet,
-  [chapel.chainId]: chapel,
-  [ganache.chainId]: ganache,
-};
 
 const setUpSdk = (chainId: number, provider: JsonRpcProvider) => {
   return new MidasSdk(provider, chainIdToConfig[chainId], logger);

--- a/packages/chains/src/index.ts
+++ b/packages/chains/src/index.ts
@@ -1,9 +1,25 @@
-export { default as bsc } from "./bsc";
-export { default as polygon } from "./polygon";
-export { default as moonbeam } from "./moonbeam";
-export { default as ganache } from "./ganache";
-export { default as neondevnet } from "./neondevnet";
-export { default as evmos } from "./evmos";
-export { default as chapel } from "./chapel";
-export { default as arbitrum } from "./arbitrum";
-export { default as fantom } from "./fantom";
+import { ChainConfig } from "@midas-capital/types";
+
+import { default as arbitrum } from "./arbitrum";
+import { default as bsc } from "./bsc";
+import { default as chapel } from "./chapel";
+import { default as evmos } from "./evmos";
+import { default as fantom } from "./fantom";
+import { default as ganache } from "./ganache";
+import { default as moonbeam } from "./moonbeam";
+import { default as neondevnet } from "./neondevnet";
+import { default as polygon } from "./polygon";
+
+export { bsc, polygon, moonbeam, arbitrum, evmos, chapel, ganache, neondevnet, fantom };
+
+export const chainIdToConfig: { [chainId: number]: ChainConfig } = {
+  [bsc.chainId]: bsc,
+  [polygon.chainId]: polygon,
+  [moonbeam.chainId]: moonbeam,
+  [arbitrum.chainId]: arbitrum,
+  [evmos.chainId]: evmos,
+  [chapel.chainId]: chapel,
+  [ganache.chainId]: ganache,
+  [neondevnet.chainId]: neondevnet,
+  [fantom.chainId]: fantom,
+};

--- a/packages/monitors/liquidity/src/types/config.ts
+++ b/packages/monitors/liquidity/src/types/config.ts
@@ -1,16 +1,10 @@
 import { MidasSdk } from "@midas-capital/sdk";
-import { arbitrum, bsc, moonbeam, polygon } from "@midas-capital/chains";
-import { ChainConfig, SupportedAsset } from "@midas-capital/types";
-import { AMMLiquidityVerifier } from "../services";
-import { TAssetConfig } from "./asset";
-import { LiquidityPoolKind, LiquidityMonitorChains } from "./pool";
+import { SupportedAsset } from "@midas-capital/types";
 
-export const chainIdToConfig: { [chainId: number]: ChainConfig } = {
-  [bsc.chainId]: bsc,
-  [polygon.chainId]: polygon,
-  [moonbeam.chainId]: moonbeam,
-  [arbitrum.chainId]: arbitrum,
-};
+import { AMMLiquidityVerifier } from "../services";
+
+import { TAssetConfig } from "./asset";
+import { LiquidityMonitorChains, LiquidityPoolKind } from "./pool";
 
 export type TVerifier = typeof AMMLiquidityVerifier;
 

--- a/packages/monitors/liquidity/tests/helpers.ts
+++ b/packages/monitors/liquidity/tests/helpers.ts
@@ -1,9 +1,9 @@
 import { JsonRpcProvider } from "@ethersproject/providers";
+import { chainIdToConfig } from "@midas-capital/chains";
 import { SupportedChains } from "@midas-capital/types";
 import { Signer, Wallet } from "ethers";
 
 import { baseConfig } from "../src/config/variables";
-import { chainIdToConfig } from "../src/types";
 /**
  * Creates an eth-address compatible string with given prefix
  *

--- a/packages/monitors/liquidity/tests/services/liqudityVerifier.spec.ts
+++ b/packages/monitors/liquidity/tests/services/liqudityVerifier.spec.ts
@@ -1,4 +1,4 @@
-import { bsc } from "@midas-capital/chains";
+import { bsc, chainIdToConfig } from "@midas-capital/chains";
 import { MidasSdk } from "@midas-capital/sdk";
 import { assetFilter, assetSymbols, SupportedChains, underlying } from "@midas-capital/types";
 import { restore } from "sinon";
@@ -6,7 +6,7 @@ import { restore } from "sinon";
 import { configs } from "../../src/config";
 import { AMMLiquidityVerifier } from "../../src/services/monitor";
 import { AbstractLiquidityVerifier } from "../../src/services/monitor/base";
-import { chainIdToConfig, Services } from "../../src/types";
+import { Services } from "../../src/types";
 import { expect } from "../globalTestHook";
 import { getSigner } from "../helpers";
 

--- a/packages/monitors/oracle/src/config/assets.ts
+++ b/packages/monitors/oracle/src/config/assets.ts
@@ -1,6 +1,7 @@
+import { chainIdToConfig } from "@midas-capital/chains";
 import { assetSymbols, OracleTypes, SupportedAsset } from "@midas-capital/types";
 
-import { chainIdToConfig, Services } from "../types";
+import { Services } from "../types";
 
 import { chainIdToAssets } from "./priceChangeVerifier";
 import { baseConfig } from "./variables";

--- a/packages/monitors/oracle/src/config/priceChangeVerifier/bsc.ts
+++ b/packages/monitors/oracle/src/config/priceChangeVerifier/bsc.ts
@@ -1,6 +1,7 @@
+import { chainIdToConfig } from "@midas-capital/chains";
 import { assetFilter, assetSymbols, SupportedChains } from "@midas-capital/types";
 
-import { chainIdToConfig, PriceChangeVerifierAsset } from "../../types";
+import { PriceChangeVerifierAsset } from "../../types";
 
 import { lsdPriceChangeDefaults, midCapPriceChangeDefaults, stablePriceChangeDefaults } from "./defaults";
 

--- a/packages/monitors/oracle/src/config/priceChangeVerifier/evmos.ts
+++ b/packages/monitors/oracle/src/config/priceChangeVerifier/evmos.ts
@@ -1,6 +1,7 @@
+import { chainIdToConfig } from "@midas-capital/chains";
 import { assetFilter, assetSymbols, SupportedChains } from "@midas-capital/types";
 
-import { chainIdToConfig, PriceChangeVerifierAsset } from "../../types";
+import { PriceChangeVerifierAsset } from "../../types";
 
 import { stablePriceChangeDefaults } from "./defaults";
 

--- a/packages/monitors/oracle/src/config/priceChangeVerifier/moonbeam.ts
+++ b/packages/monitors/oracle/src/config/priceChangeVerifier/moonbeam.ts
@@ -1,6 +1,7 @@
+import { chainIdToConfig } from "@midas-capital/chains";
 import { assetFilter, assetSymbols, SupportedChains } from "@midas-capital/types";
 
-import { chainIdToConfig, PriceChangeVerifierAsset } from "../../types";
+import { PriceChangeVerifierAsset } from "../../types";
 
 import { lsdPriceChangeDefaults, smallCapPriceChangeDefaults, stablePriceChangeDefaults } from "./defaults";
 

--- a/packages/monitors/oracle/src/config/priceChangeVerifier/polygon.ts
+++ b/packages/monitors/oracle/src/config/priceChangeVerifier/polygon.ts
@@ -1,6 +1,7 @@
+import { chainIdToConfig } from "@midas-capital/chains";
 import { assetFilter, assetSymbols, SupportedChains } from "@midas-capital/types";
 
-import { chainIdToConfig, PriceChangeVerifierAsset } from "../../types";
+import { PriceChangeVerifierAsset } from "../../types";
 
 import {
   lsdPriceChangeDefaults,

--- a/packages/monitors/oracle/src/setUpSdk.ts
+++ b/packages/monitors/oracle/src/setUpSdk.ts
@@ -1,19 +1,7 @@
 import { JsonRpcProvider } from "@ethersproject/providers";
-import { bsc, chapel, evmos, fantom, ganache, moonbeam, neondevnet, polygon } from "@midas-capital/chains";
+import { chainIdToConfig } from "@midas-capital/chains";
 import { MidasSdk } from "@midas-capital/sdk";
-import { ChainConfig } from "@midas-capital/types";
 import { Signer } from "ethers";
-
-const chainIdToConfig: { [chainId: number]: ChainConfig } = {
-  [bsc.chainId]: bsc,
-  [polygon.chainId]: polygon,
-  [moonbeam.chainId]: moonbeam,
-  [neondevnet.chainId]: neondevnet,
-  [chapel.chainId]: chapel,
-  [ganache.chainId]: ganache,
-  [evmos.chainId]: evmos,
-  [fantom.chainId]: fantom,
-};
 
 const setUpSdk = (chainId: number, provider: Signer | JsonRpcProvider) => {
   return new MidasSdk(provider, chainIdToConfig[chainId]);

--- a/packages/monitors/oracle/src/types.ts
+++ b/packages/monitors/oracle/src/types.ts
@@ -1,6 +1,5 @@
-import { arbitrum, bsc, evmos, moonbeam, polygon } from "@midas-capital/chains";
 import { MidasSdk } from "@midas-capital/sdk";
-import { ChainConfig, SupportedAsset } from "@midas-capital/types";
+import { SupportedAsset } from "@midas-capital/types";
 import { BigNumber, Contract } from "ethers";
 
 import { FeedVerifier, PriceChangeVerifier, PriceVerifier } from "./services";
@@ -112,14 +111,6 @@ export type PriceVerifierConfig = BaseConfig & {
 
 export type PriceChangeVerifierConfig = BaseConfig & {
   priceDeviationPeriods: DeviationPeriodConfig;
-};
-
-export const chainIdToConfig: { [chainId: number]: ChainConfig } = {
-  [bsc.chainId]: bsc,
-  [polygon.chainId]: polygon,
-  [moonbeam.chainId]: moonbeam,
-  [arbitrum.chainId]: arbitrum,
-  [evmos.chainId]: evmos,
 };
 
 export type VerificationErrorCache = Array<{ asset: SupportedAsset; error: PriceFeedInvalidity; timestamp: number }>;

--- a/packages/monitors/oracle/tests/helpers.ts
+++ b/packages/monitors/oracle/tests/helpers.ts
@@ -1,9 +1,9 @@
 import { JsonRpcProvider } from "@ethersproject/providers";
+import { chainIdToConfig } from "@midas-capital/chains";
 import { SupportedChains } from "@midas-capital/types";
 import { Signer, Wallet } from "ethers";
 
 import { baseConfig } from "../src/config/variables";
-import { chainIdToConfig } from "../src/types";
 /**
  * Creates an eth-address compatible string with given prefix
  *

--- a/packages/monitors/oracle/tests/services/feedVerifier.spec.ts
+++ b/packages/monitors/oracle/tests/services/feedVerifier.spec.ts
@@ -1,3 +1,4 @@
+import { chainIdToConfig } from "@midas-capital/chains";
 import { MidasSdk } from "@midas-capital/sdk";
 import { assetSymbols, SupportedChains } from "@midas-capital/types";
 import { Contract } from "ethers";
@@ -6,7 +7,7 @@ import { restore } from "sinon";
 import { configs } from "../../src/config";
 import { FeedVerifier } from "../../src/services/verifiers";
 import { AbstractOracleVerifier } from "../../src/services/verifiers/base";
-import { chainIdToConfig, Services } from "../../src/types";
+import { Services } from "../../src/types";
 import { expect } from "../globalTestHook";
 import { getSigner } from "../helpers";
 

--- a/packages/monitors/oracle/tests/services/priceVerifier.spec.ts
+++ b/packages/monitors/oracle/tests/services/priceVerifier.spec.ts
@@ -1,3 +1,4 @@
+import { chainIdToConfig } from "@midas-capital/chains";
 import { MidasSdk } from "@midas-capital/sdk";
 import { assetSymbols, SupportedChains } from "@midas-capital/types";
 import { BigNumber } from "ethers";
@@ -6,7 +7,7 @@ import { restore } from "sinon";
 import { configs } from "../../src/config";
 import { PriceVerifier } from "../../src/services/verifiers";
 import { AbstractOracleVerifier } from "../../src/services/verifiers/base";
-import { chainIdToConfig, Services } from "../../src/types";
+import { Services } from "../../src/types";
 import { expect } from "../globalTestHook";
 import { getSigner } from "../helpers";
 

--- a/packages/sdk/chainDeploy/helpers/liquidators/fuseSafeLiquidator.ts
+++ b/packages/sdk/chainDeploy/helpers/liquidators/fuseSafeLiquidator.ts
@@ -1,22 +1,10 @@
-import { arbitrum, bsc, chapel, evmos, fantom, ganache, moonbeam, neondevnet, polygon } from "@midas-capital/chains";
-import { ChainConfig, CurveSwapPool, JarvisLiquidityPool } from "@midas-capital/types";
+import { chainIdToConfig } from "@midas-capital/chains";
+import { CurveSwapPool, JarvisLiquidityPool } from "@midas-capital/types";
 import { BigNumber, constants } from "ethers";
 
 import { AddressesProvider } from "../../../typechain/AddressesProvider";
 import { FuseSafeLiquidator } from "../../../typechain/FuseSafeLiquidator";
 import { LiquidatorConfigFnParams, LiquidatorDeployFnParams } from "../types";
-
-const chainIdToConfig: { [chainId: number]: ChainConfig } = {
-  [bsc.chainId]: bsc,
-  [polygon.chainId]: polygon,
-  [moonbeam.chainId]: moonbeam,
-  [arbitrum.chainId]: arbitrum,
-  [neondevnet.chainId]: neondevnet,
-  [chapel.chainId]: chapel,
-  [ganache.chainId]: ganache,
-  [fantom.chainId]: fantom,
-  [evmos.chainId]: evmos,
-};
 
 export const deployFuseSafeLiquidator = async ({
   ethers,

--- a/packages/sdk/chainDeploy/helpers/types.ts
+++ b/packages/sdk/chainDeploy/helpers/types.ts
@@ -128,7 +128,7 @@ export type LiquidatorDeployFnParams = ChainDeployFnParams & {
 export type LiquidatorConfigFnParams = {
   ethers: HardhatRuntimeEnvironment["ethers"];
   getNamedAccounts: HardhatRuntimeEnvironment["getNamedAccounts"];
-  chainId: string;
+  chainId: number;
 };
 
 export type IrmDeployFnParams = ChainDeployFnParams & {

--- a/packages/sdk/deploy/deploy.ts
+++ b/packages/sdk/deploy/deploy.ts
@@ -14,9 +14,9 @@ import { FuseFeeDistributor } from "../typechain/FuseFeeDistributor";
 
 const func: DeployFunction = async ({ run, ethers, getNamedAccounts, deployments, getChainId }): Promise<void> => {
   console.log("RPC URL: ", ethers.provider.connection.url);
-  const chainId = await getChainId();
+  const chainId = parseInt(await getChainId());
   console.log("chainId: ", chainId);
-  const MIN_BORROW_USD = chainId === "97" ? 0 : 100;
+  const MIN_BORROW_USD = chainId === 97 ? 0 : 100;
   const { deployer } = await getNamedAccounts();
   console.log("deployer: ", deployer);
   const balance = await ethers.provider.getBalance(deployer);

--- a/packages/sdk/hardhat.config.ts
+++ b/packages/sdk/hardhat.config.ts
@@ -15,6 +15,7 @@ import "./tasks/plugin";
 import "./tasks/pool";
 import "./tasks/swap";
 import "./tasks/admin";
+import "./tasks/validate";
 
 import "./tasks/flywheel";
 import "./tasks/liquidation";

--- a/packages/sdk/tasks/plugin/replace.ts
+++ b/packages/sdk/tasks/plugin/replace.ts
@@ -1,21 +1,10 @@
-import { arbitrum, bsc, chapel, fantom, ganache, moonbeam, neondevnet, polygon } from "@midas-capital/chains";
-import { ChainConfig, DeployedPlugins } from "@midas-capital/types";
+import { chainIdToConfig } from "@midas-capital/chains";
+import { DeployedPlugins } from "@midas-capital/types";
 import { task, types } from "hardhat/config";
 
 import { CErc20PluginRewardsDelegate } from "../../typechain/CErc20PluginRewardsDelegate";
 import { Comptroller } from "../../typechain/Comptroller";
 import { FuseFeeDistributor } from "../../typechain/FuseFeeDistributor";
-
-const chainIdToConfig: { [chainId: number]: ChainConfig } = {
-  [bsc.chainId]: bsc,
-  [polygon.chainId]: polygon,
-  [moonbeam.chainId]: moonbeam,
-  [arbitrum.chainId]: arbitrum,
-  [neondevnet.chainId]: neondevnet,
-  [chapel.chainId]: chapel,
-  [fantom.chainId]: fantom,
-  [ganache.chainId]: ganache,
-};
 
 task("plugins:deploy:upgradable", "Deploys the upgradable plugins from a config list").setAction(
   async ({}, { ethers, getChainId, deployments }) => {
@@ -24,7 +13,7 @@ task("plugins:deploy:upgradable", "Deploys the upgradable plugins from a config 
     console.log({ deployer: deployer.address });
     const ffd = (await ethers.getContract("FuseFeeDistributor", deployer)) as FuseFeeDistributor;
 
-    const chainid = await getChainId();
+    const chainid = parseInt(await getChainId());
     const pluginConfigs: DeployedPlugins = chainIdToConfig[chainid].deployedPlugins;
 
     const oldImplementations = [];

--- a/packages/sdk/tasks/validate/assets.ts
+++ b/packages/sdk/tasks/validate/assets.ts
@@ -1,0 +1,39 @@
+import { chainIdToConfig } from "@midas-capital/chains";
+import { SupportedAsset } from "@midas-capital/types";
+import { task } from "hardhat/config";
+
+import { FusePoolDirectory } from "../../typechain/FusePoolDirectory";
+import { FusePoolLens } from "../../typechain/FusePoolLens";
+
+export default task("validate:assets", "Get pools data").setAction(async (taskArgs, hre) => {
+  // @ts-ignore
+  const midasSdkModule = await import("../../tests/utils/midasSdk");
+  const chainId = (await hre.ethers.provider.getNetwork()).chainId;
+  const chainAssets: SupportedAsset[] = chainIdToConfig[chainId].assets.filter(
+    (x) => x.disabled == false || x.disabled == undefined
+  );
+
+  const sdk = await midasSdkModule.getOrCreateMidas();
+  const signer = await hre.ethers.getNamedSigner("deployer");
+
+  const fpl = (await hre.ethers.getContract("FusePoolLens", signer)) as FusePoolLens;
+  const fpd = (await hre.ethers.getContract("FusePoolDirectory", signer)) as FusePoolDirectory;
+  const pools: FusePoolDirectory.FusePoolStruct[] = await fpd.callStatic.getAllPools();
+
+  const allAssets = new Set<string>();
+  for (const pool of pools) {
+    // const comptroller = sdk.createComptroller(await pool.comptroller, signer);
+    const [, , ulTokens, ulSymbols] = await fpl.callStatic.getPoolSummary(pool.comptroller);
+    console.log(`Pool: ${pool.name} (${pool.comptroller})`);
+    console.log(`Assets: ${ulTokens.length}`);
+    for (const [idx, token] of ulTokens.entries()) {
+      console.log(`- ${token} (${ulSymbols[idx]})`);
+      allAssets.add(token);
+    }
+  }
+  for (const asset of chainAssets) {
+    if (!allAssets.has(asset.underlying)) {
+      console.log(`Missing asset: ${asset.symbol} (${asset.underlying})`);
+    }
+  }
+});

--- a/packages/sdk/tasks/validate/index.ts
+++ b/packages/sdk/tasks/validate/index.ts
@@ -1,0 +1,1 @@
+import "./assets";

--- a/packages/security/src/enums.ts
+++ b/packages/security/src/enums.ts
@@ -1,5 +1,4 @@
-import { arbitrum, bsc, chapel, evmos, fantom, ganache, moonbeam, neondevnet, polygon } from "@midas-capital/chains";
-import { ChainConfig, Strategy } from "@midas-capital/types";
+import { Strategy } from "@midas-capital/types";
 
 import { ChainLinkFeedHeartbeat } from "./oracle/scorers/chainlink/types";
 
@@ -13,18 +12,6 @@ export const heartbeatToSeconds: Record<ChainLinkFeedHeartbeat, number> = {
   "20m": 60 * 20,
   "6h": 6 * 60 * 60,
   "24h": 24 * 60 * 60,
-};
-
-export const chainIdToConfig: { [chainId: number]: ChainConfig } = {
-  [bsc.chainId]: bsc,
-  [arbitrum.chainId]: arbitrum,
-  [polygon.chainId]: polygon,
-  [moonbeam.chainId]: moonbeam,
-  [neondevnet.chainId]: neondevnet,
-  [chapel.chainId]: chapel,
-  [ganache.chainId]: ganache,
-  [fantom.chainId]: fantom,
-  [evmos.chainId]: evmos,
 };
 
 /* Strategy Risk Enums */

--- a/packages/security/src/index.ts
+++ b/packages/security/src/index.ts
@@ -1,8 +1,8 @@
 import { JsonRpcProvider, Web3Provider } from "@ethersproject/providers";
+import { chainIdToConfig } from "@midas-capital/chains";
 import { ChainConfig } from "@midas-capital/types";
 import { Signer } from "ethers";
 
-import { chainIdToConfig } from "./enums";
 import { withChainLinkOracleScorer, withUniswapV3OracleScorer } from "./oracle";
 import { withErc4626StrategyScorer } from "./strategy";
 

--- a/packages/security/tests/helpers.ts
+++ b/packages/security/tests/helpers.ts
@@ -1,7 +1,7 @@
 import { JsonRpcProvider } from "@ethersproject/providers";
+import { chainIdToConfig } from "@midas-capital/chains";
 import { SupportedChains } from "@midas-capital/types";
 
-import { chainIdToConfig } from "../src/enums";
 /**
  * Creates an eth-address compatible string with given prefix
  *

--- a/packages/ui/context/MultiMidasContext.tsx
+++ b/packages/ui/context/MultiMidasContext.tsx
@@ -1,4 +1,5 @@
 import { JsonRpcProvider } from '@ethersproject/providers';
+import { chainIdToConfig } from '@midas-capital/chains';
 import { MidasSdk } from '@midas-capital/sdk';
 import Security from '@midas-capital/security';
 import { SupportedChains } from '@midas-capital/types';
@@ -17,7 +18,6 @@ import {
 import { Chain, useAccount, useDisconnect, useNetwork, useSigner } from 'wagmi';
 
 import { useEnabledChains } from '@ui/hooks/useChainConfig';
-import { chainIdToConfig } from '@ui/types/ChainMetaData';
 
 export interface MultiMidasContextData {
   sdks: MidasSdk[];

--- a/packages/ui/hooks/useUSDPrices.ts
+++ b/packages/ui/hooks/useUSDPrices.ts
@@ -1,4 +1,4 @@
-import * as ChainConfigs from '@midas-capital/chains';
+import { chainIdToConfig } from '@midas-capital/chains';
 import { useQuery } from '@tanstack/react-query';
 import axios from 'axios';
 import { SupportedChains } from 'types/dist/cjs';
@@ -16,10 +16,7 @@ async function getUSDPriceOf(chainIds: SupportedChains[]): Promise<Record<string
 
   await Promise.all(
     chainIds.map(async (id) => {
-      const config = Object.values(ChainConfigs).find(
-        (config) => config.chainId.toString() === id.toString()
-      );
-
+      const config = chainIdToConfig[id];
       if (config) {
         const _cgId = config.specificParams.cgId;
         try {
@@ -37,7 +34,7 @@ async function getUSDPriceOf(chainIds: SupportedChains[]): Promise<Record<string
         }
 
         if (!prices[id.toString()]) {
-          if (config.chainId === ChainConfigs.neondevnet.chainId) {
+          if (config.chainId === chainIdToConfig[SupportedChains.neon_devnet].chainId) {
             prices[id.toString()] = {
               value: 0.05,
               symbol: config.specificParams.metadata.nativeCurrency.symbol,

--- a/packages/ui/types/ChainMetaData.ts
+++ b/packages/ui/types/ChainMetaData.ts
@@ -9,21 +9,9 @@ import {
   neondevnet,
   polygon,
 } from '@midas-capital/chains';
-import { ChainConfig, FusePoolData } from '@midas-capital/types';
+import { FusePoolData } from '@midas-capital/types';
 
 import { config } from '@ui/config/index';
-
-export const chainIdToConfig: { [chainId: number]: ChainConfig } = {
-  [bsc.chainId]: bsc,
-  [polygon.chainId]: polygon,
-  [moonbeam.chainId]: moonbeam,
-  [neondevnet.chainId]: neondevnet,
-  [chapel.chainId]: chapel,
-  [ganache.chainId]: ganache,
-  [arbitrum.chainId]: arbitrum,
-  [fantom.chainId]: fantom,
-  [evmos.chainId]: evmos,
-};
 
 export const supportedChainIdToConfig: {
   [chainId: number]: { supported: boolean; enabled: boolean };

--- a/packages/ui/utils/networkData.ts
+++ b/packages/ui/utils/networkData.ts
@@ -1,6 +1,7 @@
 import {
   arbitrum,
   bsc,
+  chainIdToConfig,
   chapel,
   evmos,
   fantom,
@@ -19,7 +20,7 @@ import { BigNumber } from 'ethers';
 
 import { config } from '@ui/config/index';
 import { MINUTES_PER_YEAR } from '@ui/constants/index';
-import { chainIdToConfig, supportedChainIdToConfig } from '@ui/types/ChainMetaData';
+import { supportedChainIdToConfig } from '@ui/types/ChainMetaData';
 
 export const isSupportedChainId = (chainId: number) => {
   return getSupportedChainIds().includes(chainId);

--- a/packages/ui/utils/web3Providers.ts
+++ b/packages/ui/utils/web3Providers.ts
@@ -1,4 +1,4 @@
-import { chainIdToConfig } from '@ui/types/ChainMetaData';
+import { chainIdToConfig } from '@midas-capital/chains';
 
 export function providerURLForChain(chainId: number) {
   const network = chainIdToConfig[chainId].specificParams.metadata;


### PR DESCRIPTION
1. Removes the  multiple `chainIdToConfig` definitions from everywhere and places it where it makes the most sense, in the `chains` packages
2. https://github.com/Midas-Protocol/monorepo/pull/1200/files#diff-2d38283ff0f62274241334f6d423956101af87a0b0d5c34661f04521ab97297e is the only place where a somewhat larger refactor was needed, as this file assumed that all the exports from the `chains` packages were just the chain configs themselves
3. Adds a new set of hardhat tasks (WIP) that aims at aggregating all the available / deployed assets and their configuration, aimed at making it easier to see which configs are discrepant or missing. See https://github.com/Midas-Protocol/monorepo/issues/1199