### PR TITLE
set provider instead of default signer

### DIFF
--- a/packages/sdk/src/modules/Flywheel.ts
+++ b/packages/sdk/src/modules/Flywheel.ts
@@ -40,7 +40,7 @@ export function withFlywheel<TBase extends CreateContractsModule = CreateContrac
     async getFlywheelMarketRewardsByPool(pool: string): Promise<FlywheelMarketRewardsInfo[]> {
       const [flywheelsOfPool, marketsOfPool] = await Promise.all([
         this.getFlywheelsByPool(pool),
-        this.createComptroller(pool).callStatic.getAllMarkets(),
+        this.createComptroller(pool, this.provider).callStatic.getAllMarkets(),
       ]);
       const strategiesOfFlywheels = await Promise.all(flywheelsOfPool.map((fw) => fw.callStatic.getAllStrategies()));
 
@@ -72,7 +72,7 @@ export function withFlywheel<TBase extends CreateContractsModule = CreateContrac
     }
 
     async getFlywheelsByPool(poolAddress: string): Promise<MidasFlywheel[]> {
-      const pool = await this.createComptroller(poolAddress);
+      const pool = await this.createComptroller(poolAddress, this.provider);
       const allRewardDistributors = await pool.callStatic.getRewardsDistributors();
       const instances = allRewardDistributors.map((address) => {
         return new Contract(address, MidasFlywheelABI, this.provider) as MidasFlywheel;
@@ -112,7 +112,7 @@ export function withFlywheel<TBase extends CreateContractsModule = CreateContrac
     }
 
     async getFlywheelClaimableRewardsForPool(poolAddress: string, account: string) {
-      const pool = this.createComptroller(poolAddress);
+      const pool = this.createComptroller(poolAddress, this.provider);
       const marketsOfPool = await pool.callStatic.getAllMarkets();
 
       const rewardDistributorsOfPool = await pool.callStatic.getRewardsDistributors();
@@ -141,7 +141,7 @@ export function withFlywheel<TBase extends CreateContractsModule = CreateContrac
     }
 
     async getFlywheelClaimableRewardsForAsset(poolAddress: string, market: string, account: string) {
-      const pool = this.createComptroller(poolAddress);
+      const pool = this.createComptroller(poolAddress, this.provider);
       const rewardDistributorsOfPool = await pool.callStatic.getRewardsDistributors();
       const flywheels = rewardDistributorsOfPool.map((address) => this.createMidasFlywheel(address));
       const flywheelWithRewards: FlywheelClaimableRewards[] = [];


### PR DESCRIPTION
 All instances by `createComptroller` functions in `Flywheel.ts` file  are used only for getting so no need to use signer.

related to this issue 
![image](https://user-images.githubusercontent.com/45715420/214448271-19083c6a-7349-4ad7-8f6d-5a7b67189d4b.png)
