### PR TITLE
Filter out Contracts Containing `test` in Filename

### DIFF
--- a/packages/sdk/scripts/move-artifacts.sh
+++ b/packages/sdk/scripts/move-artifacts.sh
@@ -2,6 +2,6 @@
 rm -rf ./artifacts
 mkdir ./artifacts
 
-for file in $(find ./lib/contracts/out -name '*.json'); do
+for file in $(find ./lib/contracts/out -name '*.json' | grep -iv test); do
     cp $file ./artifacts;
 done


### PR DESCRIPTION
Artifacts are collected in the `./artifacts` folder and only those are typed by `typechain`