### PR TITLE
user entered value should be initialized

### DIFF
--- a/packages/ui/components/pages/PoolPage/MarketsList/AdditionalInfo/FundButton/BorrowModal/index.tsx
+++ b/packages/ui/components/pages/PoolPage/MarketsList/AdditionalInfo/FundButton/BorrowModal/index.tsx
@@ -228,6 +228,7 @@ export const BorrowModal = ({
       onClose={() => {
         onClose();
         if (!isBorrowing) {
+          setUserEnteredAmount('');
           setAmount(constants.Zero);
           setIsConfirmed(false);
           setSteps([...BORROW_STEPS(asset.underlyingSymbol)]);


### PR DESCRIPTION
![Peek 2023-02-03 10-40](https://user-images.githubusercontent.com/45715420/216483009-ce40bc2e-6437-4644-9096-475e01631b9c.gif)

This happened in only borrow modal because borrow modal has slider which should be synced with input. So user entered value should be initialized when closing modal. It works now!