### PR TITLE
no need to call sdk func again

### DIFF
--- a/packages/ui/hooks/useFusePoolData.ts
+++ b/packages/ui/hooks/useFusePoolData.ts
@@ -1,68 +1,29 @@
 import { useQuery } from '@tanstack/react-query';
-import { useMemo } from 'react';
 
-import { useMultiMidas } from '@ui/context/MultiMidasContext';
-import { useSdk } from '@ui/hooks/fuse/useSdk';
-import { useAllUsdPrices } from '@ui/hooks/useAllUsdPrices';
-import { MarketData, PoolData } from '@ui/types/TokensDataMap';
+import { useCrossFusePools } from '@ui/hooks/fuse/useCrossFusePools';
+import { useEnabledChains } from '@ui/hooks/useChainConfig';
 
 export const useFusePoolData = (poolId: string, poolChainId: number) => {
-  const { address } = useMultiMidas();
-  const sdk = useSdk(poolChainId);
-  const { data: usdPrices } = useAllUsdPrices();
-  const usdPrice = useMemo(() => {
-    if (usdPrices && usdPrices[poolChainId.toString()]) {
-      return usdPrices[poolChainId.toString()].value;
-    } else {
-      return undefined;
-    }
-  }, [usdPrices, poolChainId]);
+  const enabledChains = useEnabledChains();
+  const { poolsPerChain } = useCrossFusePools([...enabledChains]);
 
   return useQuery(
-    ['useFusePoolData', poolId, address, sdk?.chainId, usdPrice],
-    async () => {
-      if (usdPrice && sdk?.chainId && poolId) {
-        const response = await sdk.fetchFusePoolData(poolId, { from: address });
-        if (response === null) {
-          return null;
-        }
-        const assetsWithPrice: MarketData[] = [];
-        const { assets } = response;
+    ['useFusePoolData', poolId, poolChainId, poolsPerChain],
+    () => {
+      if (poolsPerChain[poolChainId.toString()] && poolsPerChain[poolChainId.toString()].data) {
+        const pool = poolsPerChain[poolChainId.toString()].data?.find(
+          (pool) => pool.id.toString() === poolId
+        );
 
-        if (assets && assets.length !== 0) {
-          assets.map((asset) => {
-            assetsWithPrice.push({
-              ...asset,
-              supplyBalanceFiat: asset.supplyBalanceNative * usdPrice,
-              borrowBalanceFiat: asset.borrowBalanceNative * usdPrice,
-              totalSupplyFiat: asset.totalSupplyNative * usdPrice,
-              totalBorrowFiat: asset.totalBorrowNative * usdPrice,
-              liquidityFiat: asset.liquidityNative * usdPrice,
-            });
-          });
-        }
-        const adaptedFusePoolData: PoolData = {
-          ...response,
-          assets: assetsWithPrice.sort((a, b) =>
-            a.underlyingSymbol.localeCompare(b.underlyingSymbol)
-          ),
-          totalLiquidityFiat: response.totalLiquidityNative * usdPrice,
-          totalAvailableLiquidityFiat: response.totalAvailableLiquidityNative * usdPrice,
-          totalSuppliedFiat: response.totalSuppliedNative * usdPrice,
-          totalBorrowedFiat: response.totalBorrowedNative * usdPrice,
-          totalSupplyBalanceFiat: response.totalSupplyBalanceNative * usdPrice,
-          totalBorrowBalanceFiat: response.totalBorrowBalanceNative * usdPrice,
-        };
-
-        return adaptedFusePoolData;
-      } else {
-        return null;
+        return pool ? pool : null;
       }
+
+      return null;
     },
     {
       cacheTime: Infinity,
       staleTime: Infinity,
-      enabled: !!poolId && !!usdPrice && !!sdk?.chainId && !!poolChainId,
+      enabled: !!poolId && !!poolChainId && !!poolsPerChain,
     }
   );
 };

--- a/packages/ui/hooks/useFusePoolData.ts
+++ b/packages/ui/hooks/useFusePoolData.ts
@@ -8,7 +8,7 @@ export const useFusePoolData = (poolId: string, poolChainId: number) => {
   const { poolsPerChain } = useCrossFusePools([...enabledChains]);
 
   return useQuery(
-    ['useFusePoolData', poolId, poolChainId, poolsPerChain],
+    ['useFusePoolData', poolId, poolChainId, poolsPerChain[poolChainId.toString()]],
     () => {
       if (poolsPerChain[poolChainId.toString()] && poolsPerChain[poolChainId.toString()].data) {
         const pool = poolsPerChain[poolChainId.toString()].data?.find(
@@ -23,7 +23,11 @@ export const useFusePoolData = (poolId: string, poolChainId: number) => {
     {
       cacheTime: Infinity,
       staleTime: Infinity,
-      enabled: !!poolId && !!poolChainId && !!poolsPerChain,
+      enabled:
+        !!poolId &&
+        !!poolChainId &&
+        !!poolsPerChain[poolChainId.toString()] &&
+        !poolsPerChain[poolChainId.toString()].isLoading,
     }
   );
 };


### PR DESCRIPTION
`useFusePoolData` hook calls `fetchFusePoolData` func of sdk. `useCrossFusePools` hook calls `fetchPoolsManual` func which uses `fetchFusePoolData` with pool ids so we don't need to call `fetchFusePoolData` func again but just need to filter the results of `useCrossFusePools`